### PR TITLE
feat: Quick Pick character switcher

### DIFF
--- a/.maestro/smoke.yaml
+++ b/.maestro/smoke.yaml
@@ -42,13 +42,18 @@ appId: ${APP_ID}
     id: 'roll'
 - takeScreenshot: 'maestro-artifacts/${PLATFORM}/03-dice'
 
-# Settings
+# Settings — the Quick Pick grid sits above the tiles, so the Game section
+# (Statistics/Settings) is below the fold on Home; scroll it into view first.
 - stopApp
 - launchApp
 - extendedWaitUntil:
     visible:
         id: 'tile-All Characters'
     timeout: 90000
+- scrollUntilVisible:
+    element:
+        id: 'tile-Settings'
+    timeout: 20000
 - tapOn:
     id: 'tile-Settings'
 - assertVisible: 'Settings'
@@ -61,6 +66,10 @@ appId: ${APP_ID}
     visible:
         id: 'tile-All Characters'
     timeout: 90000
+- scrollUntilVisible:
+    element:
+        id: 'tile-Statistics'
+    timeout: 20000
 - tapOn:
     id: 'tile-Statistics'
 - assertVisible: 'Statistics'

--- a/src/app/components/CharacterPickerModal.tsx
+++ b/src/app/components/CharacterPickerModal.tsx
@@ -1,0 +1,105 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The Quick Pick curate sheet: what a long-press on a slot opens.
+ *
+ * Lists the characters available to pin — the caller passes candidates already stripped of anything
+ * pinned elsewhere, since a character lives in one slot only. When the slot already holds a pin,
+ * `canRemove` adds an "empty this slot" action at the top, so one gesture covers both replace and
+ * remove.
+ */
+import React from 'react';
+import {Modal, Pressable, ScrollView, StyleSheet, type ViewStyle} from 'react-native';
+import type {CharacterSummary} from 'core/ports';
+import {useTheme} from 'app/theme';
+import {Button} from './Button';
+import {ListRow} from './ListRow';
+import {Text} from './Text';
+
+export interface CharacterPickerModalProps {
+    visible: boolean;
+    /** Characters that may be pinned here — already filtered to those not pinned elsewhere. */
+    characters: CharacterSummary[];
+    /** The slot already holds a pin, so offer to clear it. */
+    canRemove: boolean;
+    onPick: (id: string) => void;
+    onRemove: () => void;
+    onClose: () => void;
+}
+
+const subtitleOf = (character: CharacterSummary): string => [character.edition, character.player].filter(Boolean).join(' · ');
+
+export function CharacterPickerModal({visible, characters, canRemove, onPick, onRemove, onClose}: CharacterPickerModalProps): React.JSX.Element {
+    const theme = useTheme();
+    const card: ViewStyle = {backgroundColor: theme.colors.surface, borderRadius: theme.radius.lg};
+
+    return (
+        <Modal transparent visible={visible} animationType="fade" onRequestClose={onClose}>
+            {/* accessible={false}: an accessible Pressable collapses its subtree on iOS, hiding the
+                dialog content from VoiceOver/automation. Touch (dismiss/swallow) is unaffected. */}
+            <Pressable testID="picker-backdrop" style={styles.backdrop} onPress={onClose} accessible={false}>
+                <Pressable style={[styles.card, card]} onPress={() => undefined} accessible={false}>
+                    <Text variant="subtitle">{canRemove ? 'Replace or remove' : 'Pin a character'}</Text>
+
+                    {canRemove ? <Button testID="picker-remove" label="Remove from slot" variant="secondary" onPress={onRemove} /> : null}
+
+                    {characters.length === 0 ? (
+                        <Text variant="caption" muted>
+                            No other characters to pin.
+                        </Text>
+                    ) : (
+                        <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
+                            {characters.map((character) => (
+                                <ListRow
+                                    key={character.id}
+                                    testID={`picker-row-${character.id}`}
+                                    title={character.name}
+                                    subtitle={subtitleOf(character)}
+                                    imageUri={character.portraitUri}
+                                    imageFocus={character.portraitFocus}
+                                    active={character.isActive}
+                                    onPress={() => onPick(character.id)}
+                                />
+                            ))}
+                        </ScrollView>
+                    )}
+                </Pressable>
+            </Pressable>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    backdrop: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    card: {
+        width: '100%',
+        maxWidth: 380,
+        padding: 20,
+        rowGap: 12,
+    },
+    list: {
+        // Keep the sheet from swallowing the screen when the library is large; the rest scrolls.
+        maxHeight: 360,
+    },
+    listContent: {
+        rowGap: 8,
+    },
+});

--- a/src/app/components/QuickPick.tsx
+++ b/src/app/components/QuickPick.tsx
@@ -1,0 +1,66 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Quick Pick, inline: the grid plus its curate sheet, wired to the store.
+ *
+ * This is the whole switcher as it appears on Home. The character sheet hosts the same grid inside a
+ * pull-up ({@link QuickPickSheet}); both share {@link useQuickPick}, so behaviour can't drift
+ * between them.
+ */
+import React, {useMemo, useState} from 'react';
+import {CharacterPickerModal} from './CharacterPickerModal';
+import {QuickPickGrid} from './QuickPickGrid';
+import {useQuickPick} from './useQuickPick';
+
+export interface QuickPickProps {
+    /** Open a chosen character. Quick Pick marks it active first. */
+    onActivate: (id: string) => void;
+    /** Bump to reload when the host regains focus. */
+    refreshToken?: unknown;
+}
+
+export function QuickPick({onActivate, refreshToken}: QuickPickProps): React.JSX.Element {
+    const {slots, candidates, activate, pin, removePin} = useQuickPick({onActivate, refreshToken});
+    const [editing, setEditing] = useState<number | null>(null);
+
+    // A character lives in one slot: never offer one that's already pinned somewhere.
+    const pinnedIds = useMemo(() => new Set(slots.filter((slot) => slot.kind === 'pinned').map((slot) => slot.character!.id)), [slots]);
+    const candidatesForPicker = useMemo(() => candidates.filter((character) => !pinnedIds.has(character.id)), [candidates, pinnedIds]);
+    const canRemove = editing !== null && slots[editing]?.kind === 'pinned';
+
+    return (
+        <>
+            <QuickPickGrid slots={slots} onActivate={activate} onEditSlot={setEditing} />
+            <CharacterPickerModal
+                visible={editing !== null}
+                characters={candidatesForPicker}
+                canRemove={canRemove}
+                onPick={(id) => {
+                    if (editing !== null) {
+                        pin(editing, id);
+                    }
+                    setEditing(null);
+                }}
+                onRemove={() => {
+                    if (editing !== null) {
+                        removePin(editing);
+                    }
+                    setEditing(null);
+                }}
+                onClose={() => setEditing(null)}
+            />
+        </>
+    );
+}

--- a/src/app/components/QuickPickGrid.tsx
+++ b/src/app/components/QuickPickGrid.tsx
@@ -1,0 +1,145 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The Quick Pick grid: nine character tiles, three across.
+ *
+ * Presentational only — it renders whatever {@link Slot}s it is handed and reports two intents.
+ * **Tap** a tile with a character means "make this the one I'm looking at" (`onActivate`); it never
+ * pins, so a borrowed suggestion is not silently promoted just by opening it. **Long-press** any
+ * tile — filled or empty — means "curate this slot" (`onEditSlot`), which the host turns into the
+ * pick/remove picker.
+ *
+ * Committed pins carry a small dot so you can tell what you've curated from what the grid borrowed;
+ * the active character wears a ring. Suggestions are drawn at full strength — dimming them read as
+ * "artificially dark", worst on transparent portraits, and made a fresh (all-suggestion) grid murky.
+ */
+import React from 'react';
+import {Pressable, StyleSheet, View, type ViewStyle} from 'react-native';
+import {useTheme} from 'app/theme';
+import {PortraitImage} from './PortraitImage';
+import {Text} from './Text';
+import type {Slot} from './quickPick/slots';
+
+export interface QuickPickGridProps {
+    slots: Slot[];
+    /** Tap a filled tile: make that character active and open it. */
+    onActivate: (id: string) => void;
+    /** Long-press any tile: curate that grid position. */
+    onEditSlot: (position: number) => void;
+}
+
+const initialOf = (name: string): string => (name.trim()[0] ?? '?').toUpperCase();
+
+export function QuickPickGrid({slots, onActivate, onEditSlot}: QuickPickGridProps): React.JSX.Element {
+    return (
+        <View style={styles.grid}>
+            {slots.map((slot) => (
+                <QuickPickTile key={slot.position} slot={slot} onActivate={onActivate} onEditSlot={onEditSlot} />
+            ))}
+        </View>
+    );
+}
+
+function QuickPickTile({slot, onActivate, onEditSlot}: {slot: Slot; onActivate: (id: string) => void; onEditSlot: (position: number) => void}): React.JSX.Element {
+    const theme = useTheme();
+    const {character, kind, position} = slot;
+    const active = character?.isActive === true;
+
+    const square: ViewStyle = {
+        backgroundColor: theme.colors.surfaceAlt,
+        borderRadius: theme.radius.md,
+        // The ring is the active marker; a matching-width transparent border keeps every tile the
+        // same size so activating one doesn't nudge the grid.
+        borderWidth: 2,
+        borderColor: active ? theme.colors.active : 'transparent',
+    };
+
+    const label =
+        character !== null
+            ? `${character.name}${kind === 'suggested' ? ', recent' : ''}${active ? ', active' : ''}`
+            : `Empty slot ${position + 1}, long press to add a character`;
+
+    return (
+        <Pressable
+            testID={`quickpick-slot-${position}`}
+            accessibilityRole="button"
+            accessibilityLabel={label}
+            // Tap only means something on a filled tile; an empty slot is long-press-to-add.
+            onPress={character !== null ? () => onActivate(character.id) : undefined}
+            onLongPress={() => onEditSlot(position)}
+            style={styles.tile}>
+            <View style={[styles.square, square]}>
+                {character !== null && character.portraitUri !== null ? (
+                    <PortraitImage testID={`quickpick-portrait-${position}`} uri={character.portraitUri} focus={character.portraitFocus} />
+                ) : character !== null ? (
+                    <Text variant="title" muted>
+                        {initialOf(character.name)}
+                    </Text>
+                ) : (
+                    <Text testID={`quickpick-empty-${position}`} variant="title" muted>
+                        +
+                    </Text>
+                )}
+                {kind === 'pinned' ? <View testID={`quickpick-pinned-${position}`} style={[styles.dot, {backgroundColor: theme.colors.primary}]} /> : null}
+            </View>
+            {character !== null ? (
+                <Text testID={`quickpick-name-${position}`} variant="caption" numberOfLines={1} style={styles.name}>
+                    {character.name}
+                </Text>
+            ) : (
+                <Text variant="caption" muted numberOfLines={1} style={styles.name}>
+                    &nbsp;
+                </Text>
+            )}
+            {active ? <View testID={`quickpick-active-${position}`} style={styles.activeMarker} /> : null}
+        </Pressable>
+    );
+}
+
+const styles = StyleSheet.create({
+    grid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: 12,
+    },
+    tile: {
+        flexBasis: '30%',
+        flexGrow: 1,
+        rowGap: 4,
+    },
+    square: {
+        aspectRatio: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+    },
+    dot: {
+        position: 'absolute',
+        top: 5,
+        right: 5,
+        width: 8,
+        height: 8,
+        borderRadius: 4,
+    },
+    name: {
+        textAlign: 'center',
+    },
+    // A zero-size sentinel so tests (and only tests) can assert which tile is active without
+    // reaching into style objects; the visible ring is the border above.
+    activeMarker: {
+        width: 0,
+        height: 0,
+    },
+});

--- a/src/app/components/QuickPickSheet.tsx
+++ b/src/app/components/QuickPickSheet.tsx
@@ -1,0 +1,148 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Quick Pick as a pull-up: the always-there switcher on the character sheet.
+ *
+ * A persistent handle sits at the bottom of the screen — the modern take on the legacy app's
+ * bottom-of-screen character switcher. Tapping it slides the same {@link QuickPick} grid up over a
+ * dimmed backdrop. The host must pad its scroll content by {@link QUICK_PICK_HANDLE_SPACE} so nothing
+ * hides behind the handle.
+ *
+ * The slide is a plain `Animated` translate — no `PanResponder`, no gesture library. Drag-to-dismiss
+ * is deliberately out of scope: gestures here have shipped broken twice (see CLAUDE.md), and a
+ * tap-to-open/tap-to-dismiss sheet needs none of that surface. Reduce-motion (`showAnimations`)
+ * snaps instead of sliding.
+ */
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+import {Animated, Modal, Pressable, StyleSheet, View, type ViewStyle} from 'react-native';
+import {useSettings} from 'app/providers/SettingsProvider';
+import {useTheme} from 'app/theme';
+import {QuickPick} from './QuickPick';
+import {Text} from './Text';
+
+/** Bottom padding a host's scroll content needs so the last row clears the persistent handle. */
+export const QUICK_PICK_HANDLE_SPACE = 64;
+
+/** How far below the screen the panel starts — comfortably taller than the panel itself. */
+const PANEL_OFFSET = 600;
+
+export interface QuickPickSheetProps {
+    /** Open a chosen character. On the sheet this replaces the current one (no back-stack growth). */
+    onActivate: (id: string) => void;
+    /** Bump to reload when the sheet's host regains focus. */
+    refreshToken?: unknown;
+}
+
+export function QuickPickSheet({onActivate, refreshToken}: QuickPickSheetProps): React.JSX.Element {
+    const theme = useTheme();
+    const {settings} = useSettings();
+    const [open, setOpen] = useState(false);
+    const translateY = useRef(new Animated.Value(PANEL_OFFSET)).current;
+
+    const slideTo = useCallback(
+        (to: number, done?: () => void) => {
+            if (!settings.showAnimations) {
+                translateY.setValue(to);
+                done?.();
+                return;
+            }
+            Animated.timing(translateY, {toValue: to, duration: 220, useNativeDriver: true}).start(({finished}) => {
+                if (finished) {
+                    done?.();
+                }
+            });
+        },
+        [settings.showAnimations, translateY],
+    );
+
+    // Mounting the modal (open) slides the panel up from below.
+    useEffect(() => {
+        if (open) {
+            translateY.setValue(PANEL_OFFSET);
+            slideTo(0);
+        }
+    }, [open, slideTo, translateY]);
+
+    const close = useCallback(() => slideTo(PANEL_OFFSET, () => setOpen(false)), [slideTo]);
+
+    const handle: ViewStyle = {backgroundColor: theme.colors.surface, borderColor: theme.colors.border, borderRadius: theme.radius.pill};
+    const panel: ViewStyle = {backgroundColor: theme.colors.background, borderTopLeftRadius: theme.radius.lg, borderTopRightRadius: theme.radius.lg};
+    const grabber: ViewStyle = {backgroundColor: theme.colors.border};
+
+    return (
+        <>
+            {/* box-none: only the handle takes touches; the rest of this overlay passes them through
+                to the scroll view beneath. */}
+            <View style={styles.handleWrap} pointerEvents="box-none">
+                <Pressable testID="quickpick-handle" accessibilityRole="button" accessibilityLabel="Switch character" onPress={() => setOpen(true)} style={[styles.handle, handle]}>
+                    <Text variant="label" color={theme.colors.primary}>
+                        Switch character ▲
+                    </Text>
+                </Pressable>
+            </View>
+
+            <Modal transparent visible={open} animationType="none" onRequestClose={close}>
+                {/* accessible={false}: an accessible Pressable collapses its subtree on iOS, hiding
+                    the sheet content from VoiceOver/automation. Touch (dismiss/swallow) is unaffected. */}
+                <Pressable testID="quickpick-sheet-backdrop" style={styles.backdrop} onPress={close} accessible={false}>
+                    <Animated.View style={[styles.panel, panel, {transform: [{translateY}]}]}>
+                        <Pressable onPress={() => undefined} accessible={false} style={styles.panelInner}>
+                            <View style={[styles.grabber, grabber]} />
+                            <Text variant="label" muted>
+                                SWITCH CHARACTER
+                            </Text>
+                            <QuickPick onActivate={onActivate} refreshToken={refreshToken} />
+                        </Pressable>
+                    </Animated.View>
+                </Pressable>
+            </Modal>
+        </>
+    );
+}
+
+const styles = StyleSheet.create({
+    handleWrap: {
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        alignItems: 'center',
+        paddingVertical: 10,
+    },
+    handle: {
+        paddingHorizontal: 20,
+        paddingVertical: 8,
+        borderWidth: StyleSheet.hairlineWidth,
+    },
+    backdrop: {
+        flex: 1,
+        justifyContent: 'flex-end',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    panel: {
+        paddingBottom: 24,
+    },
+    panelInner: {
+        padding: 16,
+        rowGap: 12,
+    },
+    grabber: {
+        alignSelf: 'center',
+        width: 40,
+        height: 4,
+        borderRadius: 2,
+        marginBottom: 4,
+    },
+});

--- a/src/app/components/__tests__/CharacterPickerModal.test.tsx
+++ b/src/app/components/__tests__/CharacterPickerModal.test.tsx
@@ -1,0 +1,109 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
+import type {CharacterSummary} from 'core/ports';
+import {ThemeProvider} from 'app/theme';
+import {CharacterPickerModal, type CharacterPickerModalProps} from '../CharacterPickerModal';
+
+const summary = (id: string): CharacterSummary => ({
+    id,
+    name: id.toUpperCase(),
+    player: null,
+    edition: '6E',
+    isActive: false,
+    portraitUri: null,
+    portraitFocus: null,
+});
+
+const render = (over: Partial<CharacterPickerModalProps> = {}): ReactTestRenderer => {
+    const props: CharacterPickerModalProps = {
+        visible: true,
+        characters: [summary('a'), summary('b')],
+        canRemove: false,
+        onPick: jest.fn(),
+        onRemove: jest.fn(),
+        onClose: jest.fn(),
+        ...over,
+    };
+    let tree!: ReactTestRenderer;
+    act(() => {
+        tree = TestRenderer.create(
+            <ThemeProvider colorScheme="dark">
+                <CharacterPickerModal {...props} />
+            </ThemeProvider>,
+        );
+    });
+    return tree;
+};
+
+const press = (tree: ReactTestRenderer, testID: string): void => {
+    act(() => {
+        tree.root
+            .findAllByProps({testID})
+            .find((n) => typeof n.props.onPress === 'function')
+            ?.props.onPress();
+    });
+};
+
+const exists = (tree: ReactTestRenderer, testID: string): boolean => tree.root.findAllByProps({testID}).length > 0;
+
+describe('CharacterPickerModal', () => {
+    it('lists the candidates it is given and pins the tapped one', () => {
+        const onPick = jest.fn();
+        const tree = render({characters: [summary('a'), summary('b')], onPick});
+
+        expect(exists(tree, 'picker-row-a')).toBe(true);
+        expect(exists(tree, 'picker-row-b')).toBe(true);
+
+        press(tree, 'picker-row-b');
+        expect(onPick).toHaveBeenCalledWith('b');
+    });
+
+    it('does not offer a character that is already pinned elsewhere — the caller filters it out', () => {
+        // The host passes only unpinned candidates; the modal shows exactly what it's handed.
+        const tree = render({characters: [summary('a')]});
+
+        expect(exists(tree, 'picker-row-a')).toBe(true);
+        expect(exists(tree, 'picker-row-b')).toBe(false);
+    });
+
+    it('offers Remove only when the slot already holds a pin', () => {
+        expect(exists(render({canRemove: false}), 'picker-remove')).toBe(false);
+
+        const onRemove = jest.fn();
+        const removable = render({canRemove: true, onRemove});
+        expect(exists(removable, 'picker-remove')).toBe(true);
+
+        press(removable, 'picker-remove');
+        expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses on the backdrop without choosing anything', () => {
+        const onClose = jest.fn();
+        const onPick = jest.fn();
+        const tree = render({onClose, onPick});
+
+        press(tree, 'picker-backdrop');
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onPick).not.toHaveBeenCalled();
+    });
+
+    it('shows an empty state when there is nothing left to pin', () => {
+        const tree = render({characters: []});
+        const text = tree.root.findAllByProps({}).flatMap((n) => (typeof n.props.children === 'string' ? [n.props.children] : []));
+        expect(text.join(' ')).toContain('No other characters');
+    });
+});

--- a/src/app/components/__tests__/QuickPick.test.tsx
+++ b/src/app/components/__tests__/QuickPick.test.tsx
@@ -1,0 +1,135 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
+import type {CharacterSummary, Settings} from 'core/ports';
+import {DEFAULT_SETTINGS} from 'core/ports';
+import type {Repositories} from 'infra/persistence/repositories';
+import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
+import {SettingsProvider} from 'app/providers/SettingsProvider';
+import {ThemeProvider} from 'app/theme';
+import {QuickPick} from '../QuickPick';
+
+const summary = (id: string): CharacterSummary => ({
+    id,
+    name: id.toUpperCase(),
+    player: null,
+    edition: '6E',
+    isActive: false,
+    portraitUri: null,
+    portraitFocus: null,
+});
+
+interface Options {
+    list?: CharacterSummary[];
+    recent?: CharacterSummary[];
+    settings?: Partial<Settings>;
+}
+
+interface Harness {
+    tree: ReactTestRenderer;
+    onActivate: jest.Mock;
+    setActive: jest.Mock;
+    set: jest.Mock;
+}
+
+const render = async (opts: Options = {}): Promise<Harness> => {
+    const settings: Settings = {...DEFAULT_SETTINGS, ...opts.settings};
+    const setActive = jest.fn(async () => {});
+    const set = jest.fn(async () => {});
+    const repositories = {
+        characters: {
+            list: async () => opts.list ?? [],
+            recent: async () => opts.recent ?? [],
+            setActive,
+        },
+        settings: {get: async () => settings, set},
+    } as unknown as Repositories;
+    const onActivate = jest.fn();
+
+    let tree!: ReactTestRenderer;
+    await act(async () => {
+        tree = TestRenderer.create(
+            <ThemeProvider colorScheme="dark">
+                <RepositoriesProvider repositories={repositories}>
+                    <SettingsProvider initialSettings={settings}>
+                        <QuickPick onActivate={onActivate} />
+                    </SettingsProvider>
+                </RepositoriesProvider>
+            </ThemeProvider>,
+        );
+    });
+    await act(async () => {}); // flush list/recent + settings load
+
+    return {tree, onActivate, setActive, set};
+};
+
+const fire = async (tree: ReactTestRenderer, testID: string, handler: 'onPress' | 'onLongPress'): Promise<void> => {
+    await act(async () => {
+        tree.root
+            .findAllByProps({testID})
+            .find((n) => typeof n.props[handler] === 'function')
+            ?.props[handler]();
+    });
+    await act(async () => {});
+};
+
+const exists = (tree: ReactTestRenderer, testID: string): boolean => tree.root.findAllByProps({testID}).length > 0;
+
+describe('QuickPick', () => {
+    it('activating a tile marks it active in the store, then opens it', async () => {
+        const {tree, onActivate, setActive} = await render({list: [summary('a')], recent: [summary('a')]});
+
+        await fire(tree, 'quickpick-slot-0', 'onPress');
+
+        expect(setActive).toHaveBeenCalledWith('a');
+        expect(onActivate).toHaveBeenCalledWith('a');
+    });
+
+    it('pinning a character through the picker persists the slot', async () => {
+        const {tree, set} = await render({list: [summary('a'), summary('b')], recent: [summary('a'), summary('b')]});
+
+        await fire(tree, 'quickpick-slot-0', 'onLongPress'); // curate slot 0
+        await fire(tree, 'picker-row-b', 'onPress'); // pin B there
+
+        const call = set.mock.calls.find(([key]) => key === 'pinnedCharacterIds');
+        expect(call).toBeDefined();
+        expect(call![1]).toEqual(['b', null, null, null, null, null, null, null, null]);
+
+        // The tile is now a committed pin, and carries the pinned marker.
+        expect(exists(tree, 'quickpick-pinned-0')).toBe(true);
+    });
+
+    it('never offers a character that is already pinned', async () => {
+        const {tree} = await render({list: [summary('a'), summary('b')], recent: [], settings: {pinnedCharacterIds: ['a']}});
+
+        await fire(tree, 'quickpick-slot-1', 'onLongPress'); // an empty slot
+
+        expect(exists(tree, 'picker-row-a')).toBe(false); // 'a' is pinned in slot 0
+        expect(exists(tree, 'picker-row-b')).toBe(true);
+    });
+
+    it('removing a pin empties its slot', async () => {
+        const {tree, set} = await render({list: [summary('a')], recent: [], settings: {pinnedCharacterIds: ['a']}});
+
+        await fire(tree, 'quickpick-slot-0', 'onLongPress'); // the pinned slot offers Remove
+        expect(exists(tree, 'picker-remove')).toBe(true);
+
+        await fire(tree, 'picker-remove', 'onPress');
+
+        const call = set.mock.calls.find(([key]) => key === 'pinnedCharacterIds');
+        expect(call![1]).toEqual([null, null, null, null, null, null, null, null, null]);
+    });
+});

--- a/src/app/components/__tests__/QuickPickGrid.test.tsx
+++ b/src/app/components/__tests__/QuickPickGrid.test.tsx
@@ -1,0 +1,108 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
+import type {CharacterSummary} from 'core/ports';
+import {ThemeProvider} from 'app/theme';
+import {QuickPickGrid} from '../QuickPickGrid';
+import type {Slot} from '../quickPick/slots';
+
+const summary = (over: Partial<CharacterSummary> & {id: string}): CharacterSummary => ({
+    name: over.id.toUpperCase(),
+    player: null,
+    edition: '6E',
+    isActive: false,
+    portraitUri: null,
+    portraitFocus: null,
+    ...over,
+});
+
+const slot = (position: number, kind: Slot['kind'], character: CharacterSummary | null): Slot => ({position, kind, character});
+
+const render = (slots: Slot[], handlers: {onActivate?: (id: string) => void; onEditSlot?: (position: number) => void} = {}): ReactTestRenderer => {
+    let tree!: ReactTestRenderer;
+    act(() => {
+        tree = TestRenderer.create(
+            <ThemeProvider colorScheme="dark">
+                <QuickPickGrid slots={slots} onActivate={handlers.onActivate ?? jest.fn()} onEditSlot={handlers.onEditSlot ?? jest.fn()} />
+            </ThemeProvider>,
+        );
+    });
+    return tree;
+};
+
+const node = (tree: ReactTestRenderer, testID: string, has: 'onPress' | 'onLongPress') =>
+    tree.root.findAllByProps({testID}).find((n) => typeof n.props[has] === 'function');
+
+const exists = (tree: ReactTestRenderer, testID: string): boolean => tree.root.findAllByProps({testID}).length > 0;
+
+describe('QuickPickGrid', () => {
+    it('activates the character under a tapped tile — never the wrong one', () => {
+        const onActivate = jest.fn();
+        const slots = [slot(0, 'pinned', summary({id: 'a'})), slot(1, 'suggested', summary({id: 'b'})), slot(2, 'empty', null)];
+        const tree = render(slots, {onActivate});
+
+        act(() => node(tree, 'quickpick-slot-1', 'onPress')?.props.onPress());
+        expect(onActivate).toHaveBeenCalledWith('b');
+    });
+
+    it('tapping is activate, not pin — a suggestion opens without being committed', () => {
+        const onActivate = jest.fn();
+        const onEditSlot = jest.fn();
+        const tree = render([slot(0, 'suggested', summary({id: 'b'}))], {onActivate, onEditSlot});
+
+        act(() => node(tree, 'quickpick-slot-0', 'onPress')?.props.onPress());
+
+        expect(onActivate).toHaveBeenCalledWith('b');
+        expect(onEditSlot).not.toHaveBeenCalled();
+    });
+
+    it('long-press curates the slot at its position', () => {
+        const onEditSlot = jest.fn();
+        const slots = [slot(0, 'pinned', summary({id: 'a'})), slot(1, 'empty', null)];
+        const tree = render(slots, {onEditSlot});
+
+        act(() => node(tree, 'quickpick-slot-1', 'onLongPress')?.props.onLongPress());
+        expect(onEditSlot).toHaveBeenCalledWith(1);
+    });
+
+    it('an empty tile has no tap action but can still be long-pressed to add', () => {
+        const onActivate = jest.fn();
+        const onEditSlot = jest.fn();
+        const tree = render([slot(0, 'empty', null)], {onActivate, onEditSlot});
+
+        // No onPress handler at all on an empty tile.
+        expect(node(tree, 'quickpick-slot-0', 'onPress')).toBeUndefined();
+        act(() => node(tree, 'quickpick-slot-0', 'onLongPress')?.props.onLongPress());
+        expect(onEditSlot).toHaveBeenCalledWith(0);
+        expect(onActivate).not.toHaveBeenCalled();
+    });
+
+    it('marks pinned tiles, and only pinned tiles', () => {
+        const slots = [slot(0, 'pinned', summary({id: 'a'})), slot(1, 'suggested', summary({id: 'b'}))];
+        const tree = render(slots);
+
+        expect(exists(tree, 'quickpick-pinned-0')).toBe(true);
+        expect(exists(tree, 'quickpick-pinned-1')).toBe(false);
+    });
+
+    it('rings the active character', () => {
+        const slots = [slot(0, 'pinned', summary({id: 'a'})), slot(1, 'pinned', summary({id: 'b', isActive: true}))];
+        const tree = render(slots);
+
+        expect(exists(tree, 'quickpick-active-0')).toBe(false);
+        expect(exists(tree, 'quickpick-active-1')).toBe(true);
+    });
+});

--- a/src/app/components/__tests__/QuickPickSheet.test.tsx
+++ b/src/app/components/__tests__/QuickPickSheet.test.tsx
@@ -1,0 +1,104 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import {Modal} from 'react-native';
+import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
+import type {CharacterSummary, Settings} from 'core/ports';
+import {DEFAULT_SETTINGS} from 'core/ports';
+import type {Repositories} from 'infra/persistence/repositories';
+import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
+import {SettingsProvider} from 'app/providers/SettingsProvider';
+import {ThemeProvider} from 'app/theme';
+import {QuickPickSheet} from '../QuickPickSheet';
+
+const summary = (id: string): CharacterSummary => ({
+    id,
+    name: id.toUpperCase(),
+    player: null,
+    edition: '6E',
+    isActive: false,
+    portraitUri: null,
+    portraitFocus: null,
+});
+
+const render = async (recent: CharacterSummary[] = [summary('a')]): Promise<{tree: ReactTestRenderer; onActivate: jest.Mock; setActive: jest.Mock}> => {
+    // Animations off: the slide resolves synchronously, so open/close is deterministic in tests.
+    const settings: Settings = {...DEFAULT_SETTINGS, showAnimations: false};
+    const setActive = jest.fn(async () => {});
+    const repositories = {
+        characters: {list: async () => recent, recent: async () => recent, setActive},
+        settings: {get: async () => settings, set: async () => {}},
+    } as unknown as Repositories;
+    const onActivate = jest.fn();
+
+    let tree!: ReactTestRenderer;
+    await act(async () => {
+        tree = TestRenderer.create(
+            <ThemeProvider colorScheme="dark">
+                <RepositoriesProvider repositories={repositories}>
+                    <SettingsProvider initialSettings={settings}>
+                        <QuickPickSheet onActivate={onActivate} />
+                    </SettingsProvider>
+                </RepositoriesProvider>
+            </ThemeProvider>,
+        );
+    });
+    await act(async () => {});
+    return {tree, onActivate, setActive};
+};
+
+const fire = async (tree: ReactTestRenderer, testID: string, handler: 'onPress' = 'onPress'): Promise<void> => {
+    await act(async () => {
+        tree.root
+            .findAllByProps({testID})
+            .find((n) => typeof n.props[handler] === 'function')
+            ?.props[handler]();
+    });
+    await act(async () => {});
+};
+
+const sheetOpen = (tree: ReactTestRenderer): boolean => tree.root.findAllByType(Modal)[0]?.props.visible === true;
+
+describe('QuickPickSheet', () => {
+    it('shows a persistent handle and opens the sheet on tap', async () => {
+        const {tree} = await render();
+
+        expect(tree.root.findAllByProps({testID: 'quickpick-handle'}).length).toBeGreaterThan(0);
+        expect(sheetOpen(tree)).toBe(false);
+
+        await fire(tree, 'quickpick-handle');
+        expect(sheetOpen(tree)).toBe(true);
+    });
+
+    it('dismisses on the backdrop', async () => {
+        const {tree} = await render();
+
+        await fire(tree, 'quickpick-handle');
+        expect(sheetOpen(tree)).toBe(true);
+
+        await fire(tree, 'quickpick-sheet-backdrop');
+        expect(sheetOpen(tree)).toBe(false);
+    });
+
+    it('switching a character from the open sheet activates and opens it', async () => {
+        const {tree, onActivate, setActive} = await render([summary('a')]);
+
+        await fire(tree, 'quickpick-handle');
+        await fire(tree, 'quickpick-slot-0');
+
+        expect(setActive).toHaveBeenCalledWith('a');
+        expect(onActivate).toHaveBeenCalledWith('a');
+    });
+});

--- a/src/app/components/index.ts
+++ b/src/app/components/index.ts
@@ -24,6 +24,11 @@ export {SegmentedControl, type Segment, type SegmentedControlProps} from './Segm
 export {SelectField, type SelectFieldProps} from './SelectField';
 export {TrashIcon, type IconProps} from './icons';
 export {PortraitImage, type PortraitImageProps} from './PortraitImage';
+export {QuickPick, type QuickPickProps} from './QuickPick';
+export {QuickPickGrid, type QuickPickGridProps} from './QuickPickGrid';
+export {QuickPickSheet, QUICK_PICK_HANDLE_SPACE, type QuickPickSheetProps} from './QuickPickSheet';
+export {CharacterPickerModal, type CharacterPickerModalProps} from './CharacterPickerModal';
+export {computeSlots, normalizePins, SLOT_COUNT, type Slot, type SlotKind} from './quickPick/slots';
 export {
     clampScale,
     coverStyle,

--- a/src/app/components/quickPick/slots.test.ts
+++ b/src/app/components/quickPick/slots.test.ts
@@ -1,0 +1,140 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type {CharacterSummary} from 'core/ports';
+import {computeSlots, normalizePins, SLOT_COUNT, type Slot} from './slots';
+
+const summary = (id: string): CharacterSummary => ({
+    id,
+    name: id.toUpperCase(),
+    player: null,
+    edition: '6E',
+    isActive: false,
+    portraitUri: null,
+    portraitFocus: null,
+});
+
+const byIdOf = (...ids: string[]): Map<string, CharacterSummary> => new Map(ids.map((id) => [id, summary(id)]));
+
+/** A compact view of a resolved grid: the id (or null) at each position, and its kind. */
+const shape = (slots: Slot[]): Array<[string | null, string]> => slots.map((slot) => [slot.character?.id ?? null, slot.kind]);
+
+describe('normalizePins', () => {
+    it('always returns exactly nine entries', () => {
+        expect(normalizePins([]).length).toBe(SLOT_COUNT);
+        expect(normalizePins(['a', 'b']).length).toBe(SLOT_COUNT);
+        expect(normalizePins(Array.from({length: 20}, (_, i) => `c${i}`)).length).toBe(SLOT_COUNT);
+    });
+
+    it('preserves position — index is the grid slot, holes stay holes', () => {
+        expect(normalizePins([null, 'a', null, 'b'])).toEqual([null, 'a', null, 'b', null, null, null, null, null]);
+    });
+
+    it('truncates anything past the ninth slot', () => {
+        const raw = Array.from({length: 12}, (_, i) => `c${i}`);
+        expect(normalizePins(raw)).toEqual(['c0', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6', 'c7', 'c8']);
+    });
+
+    it('drops a character pinned twice, keeping the first slot', () => {
+        expect(normalizePins(['a', 'b', 'a', 'c'])).toEqual(['a', 'b', null, 'c', null, null, null, null, null]);
+    });
+
+    it('coerces junk — non-arrays, non-strings, empty strings — to holes', () => {
+        expect(normalizePins(undefined)).toEqual(Array(SLOT_COUNT).fill(null));
+        expect(normalizePins('nope')).toEqual(Array(SLOT_COUNT).fill(null));
+        expect(normalizePins([1, {}, '', 'a'])).toEqual([null, null, null, 'a', null, null, null, null, null]);
+    });
+});
+
+describe('computeSlots', () => {
+    it('is all-empty with no pins and no recents', () => {
+        const slots = computeSlots(normalizePins([]), [], byIdOf());
+        expect(slots).toHaveLength(SLOT_COUNT);
+        expect(slots.every((slot) => slot.kind === 'empty' && slot.character === null)).toBe(true);
+    });
+
+    it('fills every empty slot from recents when nothing is pinned', () => {
+        const recents = [summary('r0'), summary('r1'), summary('r2')];
+        const slots = computeSlots(normalizePins([]), recents, byIdOf('r0', 'r1', 'r2'));
+
+        expect(shape(slots).slice(0, 3)).toEqual([
+            ['r0', 'suggested'],
+            ['r1', 'suggested'],
+            ['r2', 'suggested'],
+        ]);
+        // The pool ran dry after three; the rest are true placeholders.
+        expect(slots.slice(3).every((slot) => slot.kind === 'empty')).toBe(true);
+    });
+
+    it('keeps pins in their positions and fills only the gaps around them', () => {
+        // Pin 'p' at slot 2; slots 0,1,3,4… borrow from recents.
+        const pins = normalizePins([null, null, 'p']);
+        const recents = [summary('r0'), summary('r1')];
+        const slots = computeSlots(pins, recents, byIdOf('p', 'r0', 'r1'));
+
+        expect(shape(slots).slice(0, 4)).toEqual([
+            ['r0', 'suggested'],
+            ['r1', 'suggested'],
+            ['p', 'pinned'],
+            [null, 'empty'],
+        ]);
+    });
+
+    it('never suggests a character that is already pinned', () => {
+        // 'a' is pinned and also the most-recent — it must not appear twice.
+        const pins = normalizePins(['a']);
+        const recents = [summary('a'), summary('b')];
+        const slots = computeSlots(pins, recents, byIdOf('a', 'b'));
+
+        expect(shape(slots).slice(0, 2)).toEqual([
+            ['a', 'pinned'],
+            ['b', 'suggested'],
+        ]);
+        const ids = slots.map((slot) => slot.character?.id).filter(Boolean);
+        expect(ids.filter((id) => id === 'a')).toHaveLength(1);
+    });
+
+    it('empties a slot whose pinned character no longer exists, then refills it from recents', () => {
+        // 'gone' was pinned at slot 0 but has been deleted (absent from byId).
+        const pins = normalizePins(['gone', 'keep']);
+        const recents = [summary('r0')];
+        const slots = computeSlots(pins, recents, byIdOf('keep', 'r0'));
+
+        expect(shape(slots).slice(0, 2)).toEqual([
+            ['r0', 'suggested'], // the gap the deleted pin left, refilled
+            ['keep', 'pinned'],
+        ]);
+    });
+
+    it('dedupes a recent list that repeats an id', () => {
+        const recents = [summary('r0'), summary('r0'), summary('r1')];
+        const slots = computeSlots(normalizePins([]), recents, byIdOf('r0', 'r1'));
+
+        expect(shape(slots).slice(0, 2)).toEqual([
+            ['r0', 'suggested'],
+            ['r1', 'suggested'],
+        ]);
+        expect(slots.slice(2).every((slot) => slot.kind === 'empty')).toBe(true);
+    });
+
+    it('caps at nine even with more pins and recents than fit', () => {
+        const pins = normalizePins(Array.from({length: 5}, (_, i) => `p${i}`));
+        const recents = Array.from({length: 20}, (_, i) => summary(`r${i}`));
+        const ids = ['p0', 'p1', 'p2', 'p3', 'p4', ...recents.map((r) => r.id)];
+        const slots = computeSlots(pins, recents, byIdOf(...ids));
+
+        expect(slots).toHaveLength(SLOT_COUNT);
+        expect(slots.every((slot) => slot.kind !== 'empty')).toBe(true);
+    });
+});

--- a/src/app/components/quickPick/slots.ts
+++ b/src/app/components/quickPick/slots.ts
@@ -1,0 +1,116 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The Quick Pick switcher, as pure data.
+ *
+ * A 3×3 grid of nine slots. A slot is one of three things: a **pinned** character the player
+ * deliberately parked there, a **suggested** character the grid borrowed from the recent list to
+ * fill an empty position, or **empty** (only when there is nothing recent left to borrow). Pins are
+ * a curated launcher; they are not `isActive`, which stays a single character app-wide.
+ *
+ * This module owns every invariant — length, dedup, positional pins, per-slot fill — so the rules
+ * are testable in isolation and the React layer is just wiring. Persistence stores the pins as raw
+ * JSON and validates nothing on the way back, so {@link normalizePins} is the guard.
+ */
+import type {CharacterSummary} from 'core/ports';
+
+/** The grid is always this many slots — one page, no pagination. */
+export const SLOT_COUNT = 9;
+
+export type SlotKind = 'pinned' | 'suggested' | 'empty';
+
+export interface Slot {
+    /** Grid position, 0–8. */
+    position: number;
+    /** The character shown here, or null for an empty placeholder. */
+    character: CharacterSummary | null;
+    kind: SlotKind;
+}
+
+const isId = (value: unknown): value is string => typeof value === 'string' && value.length > 0;
+
+/**
+ * Coerce a stored pin list into exactly {@link SLOT_COUNT} entries of `string | null`.
+ *
+ * Defensive because the settings store hands back whatever JSON was written with no shape check: a
+ * non-array, a wrong length, non-string entries, or the same id pinned twice all have to resolve to
+ * something sane. A repeated id keeps its first position and nulls the rest — a character can only
+ * occupy one slot, since two slots holding the same character is two launchers for one thing.
+ */
+export function normalizePins(raw: unknown): (string | null)[] {
+    const source = Array.isArray(raw) ? raw : [];
+    const seen = new Set<string>();
+    const pins: (string | null)[] = [];
+
+    for (let i = 0; i < SLOT_COUNT; i++) {
+        const value = source[i];
+        if (isId(value) && !seen.has(value)) {
+            seen.add(value);
+            pins.push(value);
+        } else {
+            pins.push(null);
+        }
+    }
+
+    return pins;
+}
+
+/**
+ * Resolve the nine slots for display.
+ *
+ * Committed pins take their positions first (a pinned id that no longer resolves — a deleted
+ * character — falls back to empty and is refilled like any other gap). Every still-empty position is
+ * then filled, left to right, from the recent list with the pinned characters removed, so a
+ * suggestion never duplicates a pin. Whatever is left over is a true empty placeholder.
+ *
+ * @param pins   positional pins (normalize first); index is grid position
+ * @param recents recent characters, most-recent first — the suggestion pool
+ * @param byId   every known character by id, for resolving pinned ids
+ */
+export function computeSlots(pins: (string | null)[], recents: CharacterSummary[], byId: Map<string, CharacterSummary>): Slot[] {
+    const pinnedIds = new Set<string>();
+    const slots: Slot[] = [];
+
+    for (let position = 0; position < SLOT_COUNT; position++) {
+        const id = pins[position] ?? null;
+        const character = id !== null ? byId.get(id) ?? null : null;
+        if (character !== null) {
+            pinnedIds.add(character.id);
+            slots.push({position, character, kind: 'pinned'});
+        } else {
+            slots.push({position, character: null, kind: 'empty'});
+        }
+    }
+
+    // The suggestion pool: recents that aren't already pinned, deduped, in recency order.
+    const usedAsSuggestion = new Set<string>();
+    const pool: CharacterSummary[] = [];
+    for (const candidate of recents) {
+        if (!pinnedIds.has(candidate.id) && !usedAsSuggestion.has(candidate.id)) {
+            usedAsSuggestion.add(candidate.id);
+            pool.push(candidate);
+        }
+    }
+
+    let next = 0;
+    for (const slot of slots) {
+        if (slot.kind === 'empty' && next < pool.length) {
+            slot.character = pool[next++];
+            slot.kind = 'suggested';
+        }
+    }
+
+    return slots;
+}

--- a/src/app/components/useQuickPick.ts
+++ b/src/app/components/useQuickPick.ts
@@ -1,0 +1,110 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The Quick Pick state: loads characters, resolves the nine slots, and owns the mutations.
+ *
+ * Two data sources feed the grid — the full list (for the picker, for resolving pinned ids, and for
+ * the active ring) and the recent list (the suggestion pool). Pins live in {@link Settings}; a
+ * mutation writes through `update`, and the grid re-derives from that in-memory change with no
+ * reload. Reloading from the repository only matters when the *underlying* data moves (a character
+ * opened, deleted, or its active flag changed elsewhere), which the host signals via `refreshToken`.
+ */
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import type {CharacterSummary} from 'core/ports';
+import {useRepositories} from 'app/providers/RepositoriesProvider';
+import {useSettings} from 'app/providers/SettingsProvider';
+import {computeSlots, normalizePins, SLOT_COUNT, type Slot} from './quickPick/slots';
+
+export interface QuickPickController {
+    slots: Slot[];
+    /** Every character, for the picker to choose from. */
+    candidates: CharacterSummary[];
+    loading: boolean;
+    /** Make a character active and hand it to the host to open. */
+    activate: (id: string) => void;
+    /** Pin a character at a grid position, clearing any slot it already occupied. */
+    pin: (position: number, id: string) => void;
+    /** Empty a grid position. */
+    removePin: (position: number) => void;
+    reload: () => void;
+}
+
+export interface UseQuickPickOptions {
+    onActivate: (id: string) => void;
+    /** Bump to force a reload — the navigator does this when Quick Pick's host regains focus. */
+    refreshToken?: unknown;
+}
+
+export function useQuickPick({onActivate, refreshToken}: UseQuickPickOptions): QuickPickController {
+    const {characters} = useRepositories();
+    const {settings, update} = useSettings();
+    const [all, setAll] = useState<CharacterSummary[] | undefined>(undefined);
+    const [recents, setRecents] = useState<CharacterSummary[]>([]);
+
+    const load = useCallback(async () => {
+        try {
+            const [list, recent] = await Promise.all([characters.list(), characters.recent(SLOT_COUNT)]);
+            setAll(list);
+            setRecents(recent);
+        } catch {
+            setAll([]);
+            setRecents([]);
+        }
+    }, [characters]);
+
+    useEffect(() => {
+        load();
+    }, [load, refreshToken]);
+
+    const pins = useMemo(() => normalizePins(settings.pinnedCharacterIds), [settings.pinnedCharacterIds]);
+    const byId = useMemo(() => new Map((all ?? []).map((character) => [character.id, character])), [all]);
+    const slots = useMemo(() => computeSlots(pins, recents, byId), [pins, recents, byId]);
+
+    const activate = useCallback(
+        (id: string) => {
+            characters.setActive(id).catch(() => {
+                // Best-effort: navigation still proceeds, and the sheet re-reads the DB on next load.
+            });
+            onActivate(id);
+        },
+        [characters, onActivate],
+    );
+
+    const pin = useCallback(
+        (position: number, id: string) => {
+            const next = normalizePins(settings.pinnedCharacterIds);
+            // A character occupies exactly one slot — clear any existing home before parking it here.
+            for (let i = 0; i < next.length; i++) {
+                if (next[i] === id) {
+                    next[i] = null;
+                }
+            }
+            next[position] = id;
+            update('pinnedCharacterIds', normalizePins(next));
+        },
+        [settings.pinnedCharacterIds, update],
+    );
+
+    const removePin = useCallback(
+        (position: number) => {
+            const next = normalizePins(settings.pinnedCharacterIds);
+            next[position] = null;
+            update('pinnedCharacterIds', next);
+        },
+        [settings.pinnedCharacterIds, update],
+    );
+
+    return {slots, candidates: all ?? [], loading: all === undefined, activate, pin, removePin, reload: load};
+}

--- a/src/app/navigation/AppNavigator.tsx
+++ b/src/app/navigation/AppNavigator.tsx
@@ -99,6 +99,8 @@ export function AppNavigator(): React.JSX.Element {
                                 characterId={route.params.id}
                                 onReady={(character) => navigation.setOptions({title: character.name})}
                                 onRollRequest={(request) => navigation.navigate('Dice', {request})}
+                                // Replace, not push: flipping between characters must not grow the back stack.
+                                onSwitchCharacter={(id) => navigation.replace('CharacterDetail', {id})}
                             />
                         )}
                     </Stack.Screen>

--- a/src/app/navigation/__tests__/HomeRoute.test.tsx
+++ b/src/app/navigation/__tests__/HomeRoute.test.tsx
@@ -29,9 +29,11 @@ import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import type {CharacterRepository, CharacterSummary} from 'core/ports';
+import {DEFAULT_SETTINGS} from 'core/ports';
 import type {Repositories} from 'infra/persistence/repositories';
 import {HomeRoute, type RootStackParamList} from 'app/navigation/AppNavigator';
 import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
+import {SettingsProvider} from 'app/providers/SettingsProvider';
 import {ThemeProvider} from 'app/theme';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -73,30 +75,38 @@ const press = async (tree: ReactTestRenderer, testID: string): Promise<void> => 
 /** Mounts the real HomeRoute at Home, with a stub at Characters that can pop back. */
 const renderStack = async (recent: () => CharacterSummary[]): Promise<{tree: ReactTestRenderer; calls: () => number}> => {
     let calls = 0;
+    // The Quick Pick grid fills empty slots from `recent`, so `recent` is still the query that a
+    // focus refresh must re-run; `calls` counts loads. `list` (candidates + id resolution) reads the
+    // same set without counting, so the focus assertions below stay about the focus lifecycle.
     const characters = {
+        list: async () => recent(),
         recent: async () => {
             calls += 1;
             return recent();
         },
+        setActive: async () => {},
     } as unknown as CharacterRepository;
+    const repositories = {characters, settings: {get: async () => DEFAULT_SETTINGS, set: async () => {}}} as unknown as Repositories;
 
     let tree!: ReactTestRenderer;
     await act(async () => {
         tree = TestRenderer.create(
             <ThemeProvider colorScheme="dark">
-                <RepositoriesProvider repositories={{characters} as unknown as Repositories}>
-                    <NavigationContainer>
-                        <Stack.Navigator screenOptions={{headerShown: false}}>
-                            <Stack.Screen name="Home">{({navigation}) => <HomeRoute navigation={navigation} />}</Stack.Screen>
-                            <Stack.Screen name="CharacterList">
-                                {({navigation}) => (
-                                    <Text testID="go-back" onPress={() => navigation.goBack()}>
-                                        Characters
-                                    </Text>
-                                )}
-                            </Stack.Screen>
-                        </Stack.Navigator>
-                    </NavigationContainer>
+                <RepositoriesProvider repositories={repositories}>
+                    <SettingsProvider initialSettings={DEFAULT_SETTINGS}>
+                        <NavigationContainer>
+                            <Stack.Navigator screenOptions={{headerShown: false}}>
+                                <Stack.Screen name="Home">{({navigation}) => <HomeRoute navigation={navigation} />}</Stack.Screen>
+                                <Stack.Screen name="CharacterList">
+                                    {({navigation}) => (
+                                        <Text testID="go-back" onPress={() => navigation.goBack()}>
+                                            Characters
+                                        </Text>
+                                    )}
+                                </Stack.Screen>
+                            </Stack.Navigator>
+                        </NavigationContainer>
+                    </SettingsProvider>
                 </RepositoriesProvider>
             </ThemeProvider>,
         );
@@ -133,9 +143,9 @@ describe('HomeRoute — reload on focus', () => {
         recent = [];
         await press(tree, 'go-back');
 
-        const text = collectText(tree.toJSON());
-        expect(text).not.toContain('Defensor');
-        expect(text).toContain('No characters yet');
+        expect(collectText(tree.toJSON())).not.toContain('Defensor');
+        // Nothing recent left to borrow, so the grid falls back to empty placeholder slots.
+        expect(tree.root.findAllByProps({testID: 'quickpick-empty-0'}).length).toBeGreaterThan(0);
     });
 
     it('loads once on launch — Home mounts already focused', async () => {

--- a/src/app/screens/CharacterDetailScreen.tsx
+++ b/src/app/screens/CharacterDetailScreen.tsx
@@ -18,7 +18,7 @@ import type {LastRoll} from 'core/dice';
 import type {Character, PortraitFocus} from 'core/ports';
 import type {Obj} from 'core/traits';
 import {pointSummary, type PointSummary} from 'core/hero';
-import {Button, Card, PortraitImage, Screen, SegmentedControl, SpendChip, Text, type Segment} from 'app/components';
+import {Button, Card, PortraitImage, QuickPickSheet, QUICK_PICK_HANDLE_SPACE, Screen, SegmentedControl, SpendChip, Text, type Segment} from 'app/components';
 import {characteristicRollRequest, describeRoll, performRoll, recordRoll, traitRollRequest, type RollRequest} from 'app/dice/rollRequest';
 import {CombatStateProvider, useCombatState} from 'app/providers/CombatStateProvider';
 import {useDieRoller} from 'app/providers/DiceProvider';
@@ -51,11 +51,16 @@ export interface CharacterDetailScreenProps {
     onReady?: (character: Character) => void;
     /** Tap a roll → open the dice roller pre-filled. Long-press rolls it inline. */
     onRollRequest?: (request: RollRequest) => void;
+    /**
+     * Switch to another character from the Quick Pick sheet. The navigator replaces the current
+     * screen (rather than pushing) so flipping between characters doesn't grow the back stack.
+     */
+    onSwitchCharacter?: (id: string) => void;
 }
 
 const AVATAR = 96;
 
-export function CharacterDetailScreen({characterId, onReady, onRollRequest}: CharacterDetailScreenProps): React.JSX.Element {
+export function CharacterDetailScreen({characterId, onReady, onRollRequest, onSwitchCharacter}: CharacterDetailScreenProps): React.JSX.Element {
     const {characters: repository, statistics} = useRepositories();
     const roller = useDieRoller();
     const theme = useTheme();
@@ -189,7 +194,8 @@ export function CharacterDetailScreen({characterId, onReady, onRollRequest}: Cha
     const points = pointSummary(loaded.document, loaded.edition === '5E');
     const meta = [loaded.edition, loaded.player, points !== null ? formatPoints(points) : null].filter(Boolean).join(' · ');
     const avatarStyle: ViewStyle = {backgroundColor: theme.colors.surfaceAlt, borderRadius: theme.radius.md};
-    const content: ViewStyle = {padding: theme.spacing(4), rowGap: theme.spacing(4)};
+    // Extra bottom room so the last row clears the persistent Quick Pick handle pinned to the screen.
+    const content: ViewStyle = {padding: theme.spacing(4), rowGap: theme.spacing(4), paddingBottom: theme.spacing(4) + QUICK_PICK_HANDLE_SPACE};
 
     return (
         <Screen>
@@ -248,6 +254,7 @@ export function CharacterDetailScreen({characterId, onReady, onRollRequest}: Cha
                     <BasicBody character={loaded} />
                 )}
             </ScrollView>
+            {onSwitchCharacter !== undefined ? <QuickPickSheet onActivate={onSwitchCharacter} /> : null}
             <RollFlash flash={flash} onClose={() => setFlash(null)} onRollAgain={rollNow} />
             {loaded.portraitUri !== null ? (
                 <PortraitFramer

--- a/src/app/screens/HomeScreen.tsx
+++ b/src/app/screens/HomeScreen.tsx
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, {useCallback, useEffect, useState} from 'react';
+import React from 'react';
 import {Pressable, ScrollView, StyleSheet, View, type ViewStyle} from 'react-native';
-import type {CharacterSummary} from 'core/ports';
-import {Card, PortraitImage, Screen, Text} from 'app/components';
+import {QuickPick, Screen, Text} from 'app/components';
 import type {RollRequest} from 'app/dice/rollRequest';
-import {useRepositories} from 'app/providers/RepositoriesProvider';
 import {useTheme} from 'app/theme';
 
 type DiceMode = RollRequest['mode'];
-
-/** How many recent characters the Home dashboard shows. */
-const RECENT_LIMIT = 4;
 
 export interface HomeScreenProps {
     onOpenCharacters: () => void;
@@ -32,10 +27,10 @@ export interface HomeScreenProps {
     onOpenStatistics: () => void;
     onOpenSettings: () => void;
     /**
-     * Change this value to force a reload. "Recent" is ordered by `accessed_at`, which opening a
-     * character updates, so the list goes stale the moment you leave — and Home sits at the root of
-     * the stack and never unmounts, so mounting alone can't reload it. The navigator bumps this on
-     * focus; knowing *when* that is stays a navigator concern.
+     * Change this value to force a reload. The Quick Pick grid fills empty slots from the recent
+     * list, which is ordered by `accessed_at` and goes stale the moment you open a character — and
+     * Home sits at the root of the stack and never unmounts, so mounting alone can't reload it. The
+     * navigator bumps this on focus; knowing *when* that is stays a navigator concern.
      */
     refreshToken?: unknown;
 }
@@ -53,26 +48,11 @@ const DICE_TILES: Array<{label: string; mode: DiceMode}> = [
  * wires each callback — and reads the recent list through the repository port.
  */
 export function HomeScreen({onOpenCharacters, onOpenCharacter, onOpenDice, onOpenStatistics, onOpenSettings, refreshToken}: HomeScreenProps): React.JSX.Element {
-    const {characters} = useRepositories();
-    const [recent, setRecent] = useState<CharacterSummary[] | undefined>(undefined);
-
-    const load = useCallback(async () => {
-        try {
-            setRecent(await characters.recent(RECENT_LIMIT));
-        } catch {
-            setRecent([]);
-        }
-    }, [characters]);
-
-    useEffect(() => {
-        load();
-    }, [load, refreshToken]);
-
     return (
         <Screen>
             <ScrollView contentContainerStyle={styles.content}>
-                <Section title="Recent">
-                    <RecentCharacters characters={recent} onOpen={onOpenCharacter} />
+                <Section title="Quick Pick">
+                    <QuickPick onActivate={onOpenCharacter} refreshToken={refreshToken} />
                 </Section>
 
                 <Section title="Library">
@@ -97,57 +77,6 @@ export function HomeScreen({onOpenCharacters, onOpenCharacter, onOpenDice, onOpe
                 </Section>
             </ScrollView>
         </Screen>
-    );
-}
-
-function RecentCharacters({characters, onOpen}: {characters: CharacterSummary[] | undefined; onOpen: (id: string) => void}): React.JSX.Element {
-    if (characters === undefined) {
-        return (
-            <Card>
-                <Text muted>Loading…</Text>
-            </Card>
-        );
-    }
-
-    if (characters.length === 0) {
-        return (
-            <Card>
-                <Text>No characters yet</Text>
-                <Text variant="caption" muted>
-                    Import a character to get started.
-                </Text>
-            </Card>
-        );
-    }
-
-    return (
-        <View style={styles.recentRow}>
-            {characters.map((character) => (
-                <RecentCard key={character.id} character={character} onOpen={onOpen} />
-            ))}
-        </View>
-    );
-}
-
-function RecentCard({character, onOpen}: {character: CharacterSummary; onOpen: (id: string) => void}): React.JSX.Element {
-    const theme = useTheme();
-    const square: ViewStyle = {backgroundColor: theme.colors.surfaceAlt, borderRadius: theme.radius.md};
-
-    return (
-        <Pressable testID={`recent-${character.id}`} accessibilityRole="button" onPress={() => onOpen(character.id)} style={styles.recentCard}>
-            <View style={[styles.recentSquare, square]}>
-                {character.portraitUri ? (
-                    <PortraitImage testID={`recent-portrait-${character.id}`} uri={character.portraitUri} focus={character.portraitFocus} />
-                ) : (
-                    <Text variant="title" muted>
-                        {(character.name.trim()[0] ?? '?').toUpperCase()}
-                    </Text>
-                )}
-            </View>
-            <Text variant="caption" numberOfLines={1} style={styles.recentName}>
-                {character.name}
-            </Text>
-        </Pressable>
     );
 }
 
@@ -197,23 +126,5 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
         padding: 16,
-    },
-    recentRow: {
-        flexDirection: 'row',
-        columnGap: 10,
-    },
-    recentCard: {
-        flex: 1,
-        maxWidth: 96,
-        rowGap: 4,
-    },
-    recentSquare: {
-        aspectRatio: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-        overflow: 'hidden',
-    },
-    recentName: {
-        textAlign: 'center',
     },
 });

--- a/src/app/screens/__tests__/HomeScreen.test.tsx
+++ b/src/app/screens/__tests__/HomeScreen.test.tsx
@@ -14,9 +14,11 @@
 
 import React from 'react';
 import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
-import type {CharacterRepository, CharacterSummary} from 'core/ports';
+import type {CharacterSummary} from 'core/ports';
+import {DEFAULT_SETTINGS} from 'core/ports';
 import type {Repositories} from 'infra/persistence/repositories';
 import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
+import {SettingsProvider} from 'app/providers/SettingsProvider';
 import {ThemeProvider} from 'app/theme';
 import {HomeScreen, type HomeScreenProps} from '../HomeScreen';
 
@@ -27,7 +29,6 @@ const summary = (over: Partial<CharacterSummary> = {}): CharacterSummary => ({
     edition: '6E',
     isActive: false,
     portraitUri: null,
-    /** Unframed — reads as the centre crop every portrait got before framing existed. */
     portraitFocus: null,
     ...over,
 });
@@ -53,20 +54,38 @@ const callbacks = (): HomeScreenProps => ({
     onOpenSettings: jest.fn(),
 });
 
-const render = async (recent: CharacterSummary[], props: HomeScreenProps): Promise<ReactTestRenderer> => {
-    const repositories = {characters: {recent: async () => recent} as unknown as CharacterRepository} as unknown as Repositories;
+interface Deps {
+    characters: CharacterSummary[];
+    setActive: jest.Mock;
+}
+
+const deps = (characters: CharacterSummary[]): Deps => ({characters, setActive: jest.fn(async () => {})});
+
+const wrap = (d: Deps, props: HomeScreenProps, refreshToken?: unknown): React.JSX.Element => {
+    const repositories = {
+        characters: {list: async () => d.characters, recent: async () => d.characters, setActive: d.setActive},
+        settings: {get: async () => DEFAULT_SETTINGS, set: async () => {}},
+    } as unknown as Repositories;
+
+    return (
+        <ThemeProvider colorScheme="dark">
+            <RepositoriesProvider repositories={repositories}>
+                <SettingsProvider initialSettings={DEFAULT_SETTINGS}>
+                    <HomeScreen {...props} refreshToken={refreshToken} />
+                </SettingsProvider>
+            </RepositoriesProvider>
+        </ThemeProvider>
+    );
+};
+
+const render = async (characters: CharacterSummary[], props: HomeScreenProps): Promise<{tree: ReactTestRenderer; d: Deps}> => {
+    const d = deps(characters);
     let tree!: ReactTestRenderer;
     await act(async () => {
-        tree = TestRenderer.create(
-            <ThemeProvider colorScheme="dark">
-                <RepositoriesProvider repositories={repositories}>
-                    <HomeScreen {...props} />
-                </RepositoriesProvider>
-            </ThemeProvider>,
-        );
+        tree = TestRenderer.create(wrap(d, props));
     });
-    await act(async () => {}); // flush the recent-characters load
-    return tree;
+    await act(async () => {}); // flush the quick-pick load
+    return {tree, d};
 };
 
 const press = async (tree: ReactTestRenderer, testID: string): Promise<void> => {
@@ -74,29 +93,32 @@ const press = async (tree: ReactTestRenderer, testID: string): Promise<void> => 
     await act(async () => {
         target?.props.onPress();
     });
+    await act(async () => {});
 };
 
 describe('HomeScreen', () => {
-    it('shows recent characters and opens one when tapped', async () => {
+    it('surfaces characters in the quick pick and opens the one tapped', async () => {
         const props = callbacks();
-        const tree = await render([summary({id: 'c1', name: 'Defensor'}), summary({id: 'c2', name: 'Grond'})], props);
+        const {tree, d} = await render([summary({id: 'c1', name: 'Defensor'}), summary({id: 'c2', name: 'Grond'})], props);
 
         const text = collectText(tree.toJSON());
         expect(text).toContain('Defensor');
         expect(text).toContain('Grond');
 
-        await press(tree, 'recent-c2');
+        // Slot 1 is the second recent, Grond — tapping it activates and opens him.
+        await press(tree, 'quickpick-slot-1');
+        expect(d.setActive).toHaveBeenCalledWith('c2');
         expect(props.onOpenCharacter).toHaveBeenCalledWith('c2');
     });
 
-    it('shows an empty state when there are no characters', async () => {
-        const tree = await render([], callbacks());
-        expect(collectText(tree.toJSON())).toContain('No characters yet');
+    it('shows empty placeholder slots when there are no characters', async () => {
+        const {tree} = await render([], callbacks());
+        expect(tree.root.findAllByProps({testID: 'quickpick-empty-0'}).length).toBeGreaterThan(0);
     });
 
     it('launches a dice roller in the chosen mode', async () => {
         const props = callbacks();
-        const tree = await render([], props);
+        const {tree} = await render([], props);
 
         await press(tree, 'tile-Damage');
         expect(props.onOpenDice).toHaveBeenCalledWith('normal');
@@ -107,7 +129,7 @@ describe('HomeScreen', () => {
 
     it('navigates to the library and game tools', async () => {
         const props = callbacks();
-        const tree = await render([], props);
+        const {tree} = await render([], props);
 
         await press(tree, 'tile-All Characters');
         await press(tree, 'tile-Statistics');
@@ -119,40 +141,46 @@ describe('HomeScreen', () => {
     });
 
     /**
-     * "Recent" is ordered by `accessed_at`, so it restates itself every time it is looked at. Home
-     * never unmounts (it is the stack root), so a mount-only load would freeze the list at its
-     * launch-time order for the whole session — the navigator bumps `refreshToken` on focus.
+     * The quick pick fills empty slots from the recent list, which restates itself every time a
+     * character is opened. Home never unmounts (it is the stack root), so a mount-only load would
+     * freeze the grid at its launch-time order — the navigator bumps `refreshToken` on focus.
      */
-    it('reloads the recent list when refreshToken changes (e.g. on returning to Home)', async () => {
-        let recent = [summary({id: 'c1', name: 'Defensor'})];
-        const characters = {recent: async () => recent} as unknown as CharacterRepository;
-        const repositories = {characters} as unknown as Repositories;
-        const wrap = (token: number): React.JSX.Element => (
+    it('reloads the grid when refreshToken changes (e.g. on returning to Home)', async () => {
+        // One stable repositories object: a fresh one each render would change the loader's identity
+        // and reload on its own, hiding the very staleness this test is about.
+        const holder = {characters: [summary({id: 'c1', name: 'Defensor'})]};
+        const repositories = {
+            characters: {list: async () => holder.characters, recent: async () => holder.characters, setActive: jest.fn(async () => {})},
+            settings: {get: async () => DEFAULT_SETTINGS, set: async () => {}},
+        } as unknown as Repositories;
+        const el = (token: number): React.JSX.Element => (
             <ThemeProvider colorScheme="dark">
                 <RepositoriesProvider repositories={repositories}>
-                    <HomeScreen {...callbacks()} refreshToken={token} />
+                    <SettingsProvider initialSettings={DEFAULT_SETTINGS}>
+                        <HomeScreen {...callbacks()} refreshToken={token} />
+                    </SettingsProvider>
                 </RepositoriesProvider>
             </ThemeProvider>
         );
 
         let tree!: ReactTestRenderer;
         await act(async () => {
-            tree = TestRenderer.create(wrap(0));
+            tree = TestRenderer.create(el(0));
         });
         await act(async () => {});
         expect(collectText(tree.toJSON())).toContain('Defensor');
 
-        // Someone opened Grond, which reorders `recent`, and deleted Defensor.
-        recent = [summary({id: 'c2', name: 'Grond'})];
+        // Someone opened Grond, which reorders the recent list, and deleted Defensor.
+        holder.characters = [summary({id: 'c2', name: 'Grond'})];
 
         await act(async () => {
-            tree.update(wrap(0)); // same token: still the stale list
+            tree.update(el(0)); // same token: still the stale grid
         });
         await act(async () => {});
         expect(collectText(tree.toJSON())).toContain('Defensor');
 
         await act(async () => {
-            tree.update(wrap(1));
+            tree.update(el(1));
         });
         await act(async () => {});
 

--- a/src/core/ports/persistence.ts
+++ b/src/core/ports/persistence.ts
@@ -29,6 +29,13 @@ export interface Settings {
     colorScheme: ColorScheme;
     /** Multiplier applied to every font size (1 = default). */
     fontScale: number;
+    /**
+     * The Quick Pick switcher's slots, by grid position (index 0–8). `null` is an unpinned
+     * placeholder — the grid fills those live from the recent list. A curated launcher, distinct
+     * from {@link CharacterSummary.isActive}, which stays a single character. Persistence does no
+     * shape validation on read, so the app normalizes this (length, dedup) before trusting it.
+     */
+    pinnedCharacterIds: (string | null)[];
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -36,6 +43,7 @@ export const DEFAULT_SETTINGS: Settings = {
     showAnimations: true,
     colorScheme: 'system',
     fontScale: 1,
+    pinnedCharacterIds: [],
 };
 
 export interface SettingsRepository {


### PR DESCRIPTION
## Quick Pick — a 3×3 character switcher

Rebuilds the legacy app's multi-character switcher (five slots + a bottom-of-screen switcher) as a nicer **Quick Pick**: a 3×3 grid of character tiles. The same grid appears **inline on Home** (replacing the Recent block) and inside a **pull-up sheet on the character sheet**.

### Model
- **Pins ≠ active.** Pins are a curated launcher stored in `Settings.pinnedCharacterIds`, deliberately distinct from `is_active`, which stays a single character. They compose — the grid can hold several pins while one wears the active ring. **No schema change**: pins ride the existing generic-JSON settings table.
- **Per-slot fill.** Committed pins hold their position; every still-empty slot borrows a recent as a **full-strength suggestion**, deduped against pins. No cold-start empty grid, and no cliff when you pin your first character.
- **Interactions.** Tap = make active + open; long-press = curate (pick into an empty slot, or replace/remove a pinned one). Tap never silently pins. Committed pins carry a dot marker. Switching from the sheet uses `navigation.replace`, so flipping between characters doesn't grow the back stack.

### Design notes
- The whole invariant surface (positional pins, dedup, per-slot fill, cap-9, drop-deleted) lives in a pure module, `quickPick/slots.ts`, and is unit-tested away from React.
- **No `PanResponder`.** The sheet opens/dismisses by tap; drag-to-dismiss is deliberately out of scope, given the gesture surface has shipped broken twice in this app (see `CLAUDE.md`). Reduce-motion (`showAnimations`) snaps instead of sliding.
- Suggestions render at **full strength** — dimming them read as "artificially dark", worst on transparent portraits, and made a fresh (all-suggestion) grid murky.
- **Portrait storage is untouched** — imported `.hdc` bytes stay a faithful passthrough; nothing re-encodes.

### Files
- **Port:** `pinnedCharacterIds` added to `Settings` / `DEFAULT_SETTINGS`.
- **New:** `quickPick/slots.ts` (pure), `QuickPickGrid`, `CharacterPickerModal`, `useQuickPick`, `QuickPick` (inline), `QuickPickSheet` (pull-up) — each with tests.
- **Wired:** `HomeScreen` (dead `RecentCharacters` removed), `CharacterDetailScreen` (+ `onSwitchCharacter`), `AppNavigator`.

### Verification
- `npx tsc --noEmit` ✅ · `npm run lint` ✅
- Tests **green**: core 1687 / infra 110 / app 245 (30 new Quick Pick tests).
- Loaded on-device from a prod build; portrait-dim tweak came out of that pass.

### Out of scope (v1)
- Multi-slot / more than one active character (single-active schema untouched by design).
- Drag-to-dismiss/expand on the sheet.
- Speed Dial's relevance ranking and 3-page paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
