### PR TITLE
H12: a free skill under a Skill Enhancer stays free

### DIFF
--- a/.github/workflows/mobile-ui.yml
+++ b/.github/workflows/mobile-ui.yml
@@ -188,6 +188,12 @@ jobs:
                   api-level: 34 # solid google_apis image; bump toward 35 (the app's target) when stable on CI
                   arch: x86_64
                   profile: pixel_6
+                  # Pin software rendering. The default host-GPU path drops color buffers on CI
+                  # ("Failed to find ColorBuffer: N"), which freezes the emulator surface — the app
+                  # never paints Home and whichever flow is mid-run times out on the readiness wait.
+                  # swiftshader_indirect is deterministic on headless runners. The rest of the string
+                  # restores the action's other defaults (setting this input overrides them all).
+                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   script: |
                       adb install -r android/app/build/outputs/apk/release/app-release.apk
                       # Freeze the status bar (demo mode) so the clock can't cause visual diffs.

--- a/.maestro/smoke.yaml
+++ b/.maestro/smoke.yaml
@@ -42,18 +42,13 @@ appId: ${APP_ID}
     id: 'roll'
 - takeScreenshot: 'maestro-artifacts/${PLATFORM}/03-dice'
 
-# Settings — the Quick Pick grid sits above the tiles, so the Game section
-# (Statistics/Settings) is below the fold on Home; scroll it into view first.
+# Settings
 - stopApp
 - launchApp
 - extendedWaitUntil:
     visible:
         id: 'tile-All Characters'
     timeout: 90000
-- scrollUntilVisible:
-    element:
-        id: 'tile-Settings'
-    timeout: 20000
 - tapOn:
     id: 'tile-Settings'
 - assertVisible: 'Settings'
@@ -66,10 +61,6 @@ appId: ${APP_ID}
     visible:
         id: 'tile-All Characters'
     timeout: 90000
-- scrollUntilVisible:
-    element:
-        id: 'tile-Statistics'
-    timeout: 20000
 - tapOn:
     id: 'tile-Statistics'
 - assertVisible: 'Statistics'

--- a/.maestro/smoke.yaml
+++ b/.maestro/smoke.yaml
@@ -42,13 +42,18 @@ appId: ${APP_ID}
     id: 'roll'
 - takeScreenshot: 'maestro-artifacts/${PLATFORM}/03-dice'
 
-# Settings
+# Settings — the Quick Pick grid sits above the tiles, so the Game section
+# (Statistics/Settings) is below the fold on Home; scroll it into view first.
 - stopApp
 - launchApp
 - extendedWaitUntil:
     visible:
         id: 'tile-All Characters'
     timeout: 90000
+- scrollUntilVisible:
+    element:
+        id: 'tile-Settings'
+    timeout: 20000
 - tapOn:
     id: 'tile-Settings'
 - assertVisible: 'Settings'
@@ -61,6 +66,10 @@ appId: ${APP_ID}
     visible:
         id: 'tile-All Characters'
     timeout: 90000
+- scrollUntilVisible:
+    element:
+        id: 'tile-Statistics'
+    timeout: 20000
 - tapOn:
     id: 'tile-Statistics'
 - assertVisible: 'Statistics'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ it's data preservation, not a feature.
 **parity, not correctness** — a number of legacy bugs were preserved on purpose.
 
 > **Read [`docs/KNOWN_DEVIATIONS.md`](docs/KNOWN_DEVIATIONS.md) before changing anything in
-> `core/`.** 18 entries; 11 fixed (H3–H11, U2, U3) — every known corpus-triggered bug is now
+> `core/`.** 19 entries; 12 fixed (H3–H12, U2, U3) — every known corpus-triggered bug is now
 > fixed. It explains why a "wrong-looking" line in `core/` may be load-bearing, and why a
 > green golden master does not mean correct.
 

--- a/docs/KNOWN_DEVIATIONS.md
+++ b/docs/KNOWN_DEVIATIONS.md
@@ -48,6 +48,7 @@
 | H9 | Enhanced Perception ignores `allcost` | ✅ **fixed** — was real bug, active | yes — adamantine (9→27), jane-fawn (2→6) | traits (decorator, re-based) |
 | H10 | `Clinging.cost()` adds a stray `+1` | ✅ **fixed** — was real bug, active | yes — mark-li, aoe, spyder2022 | traits (decorator, re-based) |
 | H11 | `HandToHandAttack.roll()` computes a half-die then drops it | ✅ **fixed** — was real bug (latent) | no — the corpus never reaches the branch | none (no re-base needed) |
+| H12 | Skill Enhancer's min-1 floor charged a *free* skill 1 point | ✅ **fixed** — was real bug, active | yes — greyman, m-championsmush, twilight | traits (decorator, re-based) |
 | U1 | `capitalize` only upper-cases the first char | cosmetic (app-only) | no | (unit test) |
 | U2 | `getMultiplications(0, …)` → `-Infinity` (log of zero) | ✅ **fixed** — was real bug, active | yes — mark-li-v5a-433 (Gecko pads) | traits (decorator, re-based) |
 | U3 | `getMultiplications` off-by-one on exact powers of a non-2 step | ✅ **fixed** — was real bug (latent) | no — none; golden masters unchanged | none (no re-base needed) |
@@ -290,6 +291,32 @@ powers, tracking resistant points separately.
 - **Found** while porting STR damage to the sheet, which needed the same rule — not by the corpus,
   which cannot see it.
 - **Pinned by:** `traits/__tests__/handToHandAttack.test.ts` (reverting the fix fails 7).
+
+## H12 — Skill Enhancer's min-1 floor charged a free skill — ✅ FIXED
+
+- **Where:** `core/traits/modifierCalculator.ts` `realCost()`. The Skill Enhancer discount was
+  `realCost = realCost - 1 <= 0 ? 1 : realCost - 1`, applied to every child of an enhancer
+  (`SCIENTIST`, `JACK_OF_ALL_TRADES`, `LINGUIST`, `SCHOLAR`, `TRAVELER`, `WELL_CONNECTED`). The
+  `<= 0 ? 1` floor was meant to stop a *paid* skill's −1 reduction dropping below 1 — but it also
+  fired on a skill whose cost was already **0**, pushing it up to 1.
+- **Legacy:** same — `decorators/ModifierCalculator.js` is byte-identical, so this has been shipping.
+- **Correct:** a Skill Enhancer reduces the cost of each *related, paid* Skill by 1, to a minimum of
+  1. A free Skill — a native/everyman language (`Skill.cost()` returns 0 for `nativeTongue` /
+  `everyman` / `familiarity` at the 0 tiers) — has nothing to reduce and stays **0**. HERO Designer
+  prices a native tongue at 0 whether or not Linguist is present, so legacy is wrong here and is not
+  the oracle. **Fix:** guard the clamp on `realCost > 0`.
+- **Corpus impact:** **3 fixtures**, each a native tongue under Linguist reading 1, now 0 —
+  `greyman` (Mandaarian), `m-championsmush` (Romany, displayed "Native"), `twilight` (English). Only
+  `realCost()` moves; `cost()`/`activeCost()` are 0 in both engines. Paid skills under an enhancer are
+  unaffected — the −1 and the min-1 floor for them are untouched.
+- **Found:** chasing a "ghost" report that Skill Enhancers *don't* discount skills. They do (verified
+  across the corpus and four of Phil's own `.hdc` files); the only real defect was this opposite-
+  direction one — an enhancer *over*charging a free skill by a point.
+- **Pinned by:** `core/traits/__tests__/skillEnhancer.test.ts` — the −1/min-1 boundary at 0/1/2/5
+  points on hand-built inputs, the three corrected corpus natives at 0, and a control that a paid
+  language under Linguist still gets its −1. The decorator golden master skips just these three
+  `realCost()` comparisons via `H12_REALCOST_DIVERGENCE` and still compares their `cost()`/`activeCost()`
+  and every other trait.
 
 ## H10 — Clinging adds a stray point — ✅ FIXED
 

--- a/scripts/e2e-run.sh
+++ b/scripts/e2e-run.sh
@@ -19,18 +19,24 @@ run_suite() {
         --format junit --output "maestro-report-${PLATFORM}.xml"
 }
 
-# Retry the suite once on failure. CI emulators/simulators occasionally stall a
-# single flow's cold start (blank loading screen past the readiness timeout); a
-# fresh launch clears it. A genuine failure still fails on the retry, so this
-# recovers flakes without masking real breakage. Maestro re-runs the whole set,
-# which regenerates all screenshots (incl. the visual-regression sheet).
-run_suite
-RC=$?
-if [ "$RC" -ne 0 ]; then
-    echo "::warning::Maestro suite failed (rc=$RC) — retrying once (transient cold-start stall)."
+# Retry the suite up to twice on failure (3 attempts total). CI emulators/simulators
+# occasionally stall a single flow's cold start (blank loading screen past the readiness
+# timeout), and the Android emulator can drop a GPU color buffer ("Failed to find
+# ColorBuffer") that freezes rendering for whichever flow is mid-run — a fresh launch
+# clears both. Twice rather than once because a bad runner has glitched on two
+# consecutive passes. A genuine failure still fails on every attempt, so this recovers
+# flakes without masking real breakage. Maestro re-runs the whole set each time, which
+# regenerates all screenshots (incl. the visual-regression sheet).
+ATTEMPTS=3
+RC=0
+for attempt in $(seq 1 "$ATTEMPTS"); do
     run_suite
     RC=$?
-fi
+    [ "$RC" -eq 0 ] && break
+    if [ "$attempt" -lt "$ATTEMPTS" ]; then
+        echo "::warning::Maestro suite failed (rc=$RC) — attempt ${attempt}/${ATTEMPTS}, retrying (transient cold-start / GPU stall)."
+    fi
+done
 
 # actions/upload-artifact can't expand ~, so fold Maestro's own debug output
 # (view hierarchies + on-failure screenshots) into the workspace for upload.

--- a/src/core/traits/__tests__/decorator.goldenMaster.test.ts
+++ b/src/core/traits/__tests__/decorator.goldenMaster.test.ts
@@ -110,6 +110,24 @@ const H10_COST_DIVERGENCE: Record<string, Set<string>> = {
     spyder2022: new Set(['CLINGING']),
 };
 
+/**
+ * H12 (docs/KNOWN_DEVIATIONS.md) — intentional divergence: legacy's Skill Enhancer discount applied
+ * its "minimum 1 point" floor unconditionally, so a *free* Skill under an enhancer (a native/everyman
+ * language, cost 0) was charged 1 point. The rules reduce a *paid* Skill's cost by 1 to a floor of 1;
+ * a free Skill has nothing to reduce and stays 0 (HERO Designer agrees). Only `realCost()` diverges —
+ * `cost()`/`activeCost()` are 0 in both engines and stay compared. Keyed by fixture → `input` (the
+ * languages' visible label; `name` is null for two of the three). Corrected values pinned in
+ * `skillEnhancer.test.ts`.
+ *   - `greyman` — Mandaarian (native) under Linguist: 1 → **0**
+ *   - `m-championsmush` — Romany (native, displayed "Native") under Linguist: 1 → **0**
+ *   - `twilight` — English (native) under Linguist: 1 → **0**
+ */
+const H12_REALCOST_DIVERGENCE: Record<string, Set<string>> = {
+    greyman: new Set(['Mandaarian']),
+    'm-championsmush': new Set(['Romany']),
+    twilight: new Set(['English']),
+};
+
 describe('golden master: core/traits factory reproduces legacy', () => {
     it('covers the whole corpus', () => {
         expect(fixtures.length).toBe(37);
@@ -137,7 +155,12 @@ describe('golden master: core/traits factory reproduces legacy', () => {
                 if (!((H9_COST_DIVERGENCE[name]?.has(xmlid) ?? false) || (H10_COST_DIVERGENCE[name]?.has(xmlid) ?? false))) {
                     expect(ported.cost()).toBe(legacy.cost());
                     expect(ported.activeCost()).toBe(legacy.activeCost());
-                    expect(ported.realCost()).toBe(legacy.realCost());
+
+                    // H12 — only realCost diverges: legacy's enhancer clamp charged a free skill 1;
+                    // core keeps it 0. cost()/activeCost() (both 0) stay compared above.
+                    if (!(H12_REALCOST_DIVERGENCE[name]?.has(String(trait.input)) ?? false)) {
+                        expect(ported.realCost()).toBe(legacy.realCost());
+                    }
                 }
 
                 // Only roll() diverges for H4 — the costs still match legacy exactly.

--- a/src/core/traits/__tests__/skillEnhancer.test.ts
+++ b/src/core/traits/__tests__/skillEnhancer.test.ts
@@ -1,0 +1,95 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * H12 (docs/KNOWN_DEVIATIONS.md) — a Skill Enhancer reduces each related Skill's cost by 1, to a
+ * minimum of 1, but only for Skills the character pays for. Legacy applied the min-1 floor
+ * unconditionally, so a *free* Skill under an enhancer (a native/everyman language, cost 0) was
+ * charged 1. The corrected value here is derived from the HERO rules (a free Skill stays free) and
+ * agrees with HERO Designer, which prices a native tongue at 0 with or without Linguist — legacy is
+ * wrong at these three corpus characters, so it is not the oracle.
+ */
+import {heroDesignerCharacter as core} from 'core/hero';
+import {characterTraitDecorator} from '../index';
+import {CharacterTrait} from '../characterTrait';
+import ModifierCalculator from '../modifierCalculator';
+
+const clone = (name: string): any => JSON.parse(JSON.stringify(require(`../../hero/__tests__/fixtures/${name}.json`)));
+
+/** The visible label a Language carries can live in `name`, `input`, or `alias` across the corpus. */
+const findLanguage = (character: any, label: string): any =>
+    character.skills.find((s: any) => s.xmlid === 'LANGUAGES' && [s.name, s.input, s.alias].includes(label));
+
+/** A skill of the given base cost sitting under (or not under) a named parent, priced through ModifierCalculator. */
+const pricedUnder = (basecost: number, parentXmlid: string | null): number => {
+    const character = {skills: []};
+    const inner = new CharacterTrait({xmlid: 'LANGUAGES', basecost, modifier: undefined}, 'skills', () => character);
+    inner.parentTrait = parentXmlid === null ? undefined : {xmlid: parentXmlid};
+
+    return new ModifierCalculator(inner).realCost();
+};
+
+describe('H12: skill enhancer clamp does not charge a free skill', () => {
+    describe('the -1 / min-1 boundary (rules-derived)', () => {
+        it('leaves a free (0-cost) skill at 0', () => {
+            expect(pricedUnder(0, 'LINGUIST')).toBe(0);
+        });
+
+        it('floors a 1-cost skill at 1 (the reduction cannot drop below the minimum)', () => {
+            expect(pricedUnder(1, 'LINGUIST')).toBe(1);
+        });
+
+        it('floors a 2-cost skill at 1', () => {
+            expect(pricedUnder(2, 'LINGUIST')).toBe(1);
+        });
+
+        it('reduces a higher-cost skill by exactly 1', () => {
+            expect(pricedUnder(5, 'LINGUIST')).toBe(4);
+        });
+
+        it('does not touch a free skill with no enhancer parent', () => {
+            expect(pricedUnder(0, null)).toBe(0);
+        });
+
+        it('does not touch a paid skill with no enhancer parent', () => {
+            expect(pricedUnder(5, null)).toBe(5);
+        });
+    });
+
+    describe('corrected corpus values (were 1 under legacy, rules say 0)', () => {
+        it.each([
+            ['greyman', 'Mandaarian'],
+            ['m-championsmush', 'Native'],
+            ['twilight', 'English'],
+        ])('%s: native language "%s" under Linguist is free', (name, language) => {
+            const character: any = core.getCharacter(clone(name) as never);
+            const skill = findLanguage(character, language);
+            expect(skill).toBeDefined();
+
+            const decorated = characterTraitDecorator.decorate(skill, 'skills', () => character);
+            expect(decorated.activeCost()).toBe(0); // the language is free before the enhancer
+            expect(decorated.realCost()).toBe(0); // ...and stays free after it (legacy charged 1)
+        });
+    });
+
+    describe('control: a paid skill under an enhancer still gets its discount', () => {
+        it('greyman: English (base 3) under Linguist costs 2', () => {
+            const character: any = core.getCharacter(clone('greyman') as never);
+            const english = findLanguage(character, 'English');
+            const decorated = characterTraitDecorator.decorate(english, 'skills', () => character);
+            expect(decorated.activeCost()).toBe(3);
+            expect(decorated.realCost()).toBe(2);
+        });
+    });
+});

--- a/src/core/traits/modifierCalculator.ts
+++ b/src/core/traits/modifierCalculator.ts
@@ -53,7 +53,11 @@ export default class ModifierCalculator extends TraitDecorator {
     realCost(): number {
         let realCost = roundInPlayersFavor(this.activeCost() / (1 - this.limitations().reduce((a, b) => a + b.cost, 0)));
 
-        if (this.characterTrait.parentTrait !== undefined && SKILL_ENHANCERS.includes(this.characterTrait.parentTrait.xmlid.toUpperCase())) {
+        // A Skill Enhancer reduces each related Skill's cost by 1, to a minimum of 1 — but only for
+        // Skills the character actually pays for. A free Skill (a native/everyman language, cost 0)
+        // has nothing to reduce and must stay 0: the min-1 floor governs the reduction of a paid
+        // Skill, it does not conjure a cost for a free one. See H12 in docs/KNOWN_DEVIATIONS.md.
+        if (realCost > 0 && this.characterTrait.parentTrait !== undefined && SKILL_ENHANCERS.includes(this.characterTrait.parentTrait.xmlid.toUpperCase())) {
             realCost = realCost - 1 <= 0 ? 1 : realCost - 1;
         }
 


### PR DESCRIPTION
## What

The Skill Enhancer discount in `ModifierCalculator.realCost()` applied its "minimum 1 point" floor unconditionally (`realCost - 1 <= 0 ? 1 : realCost - 1`), so a skill that already cost **0** — a native/everyman language under Linguist (or any enhancer) — was charged **1** point instead of staying free.

The rules reduce a *paid* related skill's cost by 1, to a floor of 1; a free skill has nothing to reduce and stays 0 (HERO Designer agrees). Legacy is byte-identical and wrong here, so it is not the oracle.

**Fix:** guard the clamp on `realCost > 0`.

```ts
if (realCost > 0 && this.characterTrait.parentTrait !== undefined && SKILL_ENHANCERS.includes(...)) {
    realCost = realCost - 1 <= 0 ? 1 : realCost - 1;
}
```

## Origin

Chasing a "ghost" report that Skill Enhancers *don't* discount skills. They do — verified across the corpus and four real `.hdc` files. The only real defect was this opposite-direction one: an enhancer *over*charging a free skill by a point.

## Correctness-pass discipline (docs/KNOWN_DEVIATIONS.md → **H12**)

- **Corpus-triggered at 3 fixtures** — `greyman` (Mandaarian), `m-championsmush` (Romany, displayed "Native"), `twilight` (English), each a native tongue under Linguist reading 1, now **0**. Only `realCost()` moves; `cost()`/`activeCost()` are 0 in both engines.
- **Paid skills under enhancers are unaffected** — the −1 and the min-1 floor for them are untouched.
- **New correctness test** `skillEnhancer.test.ts` — the 0/1/2/5-point boundary on hand-built inputs (rules-derived), the three corrected corpus natives at 0, and a control that a paid language under Linguist still gets its −1.
- **Golden master re-based** via `H12_REALCOST_DIVERGENCE`, skipping **only** the three `realCost()` comparisons; their `cost()`/`activeCost()` and every other trait stay compared.
- Ledger entry + summary row added; `CLAUDE.md` count bumped to 19 entries / 12 fixed.

## Verification

`tsc` clean · lint clean · full core suite green (39 suites, 1697 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)