### PR TITLE
Author a character in the app (2.8.0), and the H2 framework-nesting fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ it's data preservation, not a feature.
 **parity, not correctness** — a number of legacy bugs were preserved on purpose.
 
 > **Read [`docs/KNOWN_DEVIATIONS.md`](docs/KNOWN_DEVIATIONS.md) before changing anything in
-> `core/`.** 19 entries; 12 fixed (H3–H12, U2, U3) — every known corpus-triggered bug is now
+> `core/`.** 19 entries; 13 fixed (H2–H12, U2, U3) — every known corpus-triggered bug is now
 > fixed. It explains why a "wrong-looking" line in `core/` may be load-bearing, and why a
 > green golden master does not mean correct.
 
@@ -167,11 +167,21 @@ Process per fix — follow it; the ledger explains the reasoning:
 3. Re-base the affected golden master to an explicit intentional divergence, with a comment
    linking back to the ledger entry (see `H3_DIVERGENCE` / `U2_DIVERGENCE` for the shape).
 
-Still open — all cosmetic, latent, or template-only; none is corpus-triggered:
+Still open — all cosmetic or template-only; none is corpus-triggered, and none has behaviour
+attached: **T1–T4** are template-output only, **H1** and **U1** are cosmetic.
 
-- **H2** is the only one with real behaviour attached (a boolean-returning sort comparator,
-  so trait *order* may be wrong). **T1–T4** are template-output only, **H1** and **U1** are
-  cosmetic.
+**H2 is a cautionary tale about this ledger's own confidence.** It sat open for the whole port
+described as display-order-only, on the reasoning that "point totals are order-independent" — which
+was true, and hid the real bug. The comparator could never move a trait earlier, and framework
+containers are appended *last* by normalization, so every Multipower, Elemental Control, VPP and
+Skill Enhancer in the corpus lost its slots to the top level: 27 of 37 fixtures, `m-championsmush`
+alone 148 orphans. Costs really were unaffected (`getParent` scans the flat list), so no cost test
+ever caught it. **A ledger entry's "corpus impact" line is a hypothesis, not a measurement** — H2's
+was written from reading the code and was wrong for years. Measure before believing one.
+
+Its fix also established that **fixing a structural quirk means teaching every caller to descend**:
+`withDescendants` (`core/util`) plus `TRAIT_CHILD_KEYS` (`core/hero`), because the child key is not
+`powers` for most categories.
 
 **Three places compute `STR / 5` into damage dice, and since H11 all three agree** — `maneuver.ts`,
 `handToHandAttack.ts`, and `heroDesignerCharacter.getStrengthDamage()`. Folding them into one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ it's data preservation, not a feature.
 **parity, not correctness** — a number of legacy bugs were preserved on purpose.
 
 > **Read [`docs/KNOWN_DEVIATIONS.md`](docs/KNOWN_DEVIATIONS.md) before changing anything in
-> `core/`.** 19 entries; 13 fixed (H2–H12, U2, U3) — every known corpus-triggered bug is now
+> `core/`.** 20 entries; 13 fixed (H2–H12, U2, U3) — every known corpus-triggered bug is now
 > fixed. It explains why a "wrong-looking" line in `core/` may be load-bearing, and why a
 > green golden master does not mean correct.
 
@@ -167,8 +167,9 @@ Process per fix — follow it; the ledger explains the reasoning:
 3. Re-base the affected golden master to an explicit intentional divergence, with a comment
    linking back to the ledger entry (see `H3_DIVERGENCE` / `U2_DIVERGENCE` for the shape).
 
-Still open — all cosmetic or template-only; none is corpus-triggered, and none has behaviour
-attached: **T1–T4** are template-output only, **H1** and **U1** are cosmetic.
+Still open — none is corpus-triggered: **T1–T4** are template-output only, **H1** and **U1** are
+cosmetic, and **H13** is latent (a Multipower slot's divisor never varies, because `ultraSlot` is
+read off the wrapper rather than the trait; every corpus slot is fixed, so nothing sees it).
 
 **H2 is a cautionary tale about this ledger's own confidence.** It sat open for the whole port
 described as display-order-only, on the reasoning that "point totals are order-independent" — which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,12 +62,19 @@ resolve in build and tests.
 ## Status
 
 **The rebuild ships.** It is on the store past legacy's cutover, the rules engine is fully
-ported and golden-mastered, and every corpus-triggered engine bug is fixed. **2.5.0
-(versionCode 65) is out to internal testing** — the first build to carry schema 5 and the
-first to change costs on characters people already have. **2.6.0 (versionCode 66) is
-staged**: 6E random characters, the Generate dialog, and portrait framing; schema 5 → 7.
-It changes no costs — 2.5.0 did that, so a cost that moves in 2.6.0 is a regression.
-What remains is CostCruncher and the cosmetic tail of the correctness pass.
+ported and golden-mastered, and every corpus-triggered engine bug is fixed. **2.7.1
+(versionCode 68) is the last build out.** **2.8.0 (versionCode 69) is staged**: in-app
+character **authoring** (see [`docs/CHARACTER_AUTHORING.md`](docs/CHARACTER_AUTHORING.md)),
+schema 7 → 8.
+
+**2.8.0 changes no costs, but it does change how a framework renders on characters people
+already have.** H2 is fixed, so a Multipower / Elemental Control / VPP nests its slots
+instead of leaving them loose beside an empty container — 27 of the 37 fixtures. The points
+were always right; only the arrangement was wrong. So in 2.8.0 a *cost* that moves is a
+regression, and a *layout* that moves is the fix.
+
+What remains is CostCruncher, the cosmetic tail of the correctness pass, and shrinking
+authoring's withheld list (`BESPOKE` in `core/authoring/catalogue.ts`).
 
 | Phase | State |
 |---|---|
@@ -75,7 +82,7 @@ What remains is CostCruncher and the cosmetic tail of the correctness pass.
 | 1 — Core port | ✅ done — `dice`, `templates`, `util`, `hero`, `traits`, `combat`; golden-mastered over all 37 fixtures |
 | 2 — Ports + infra | ✅ done — `rng`, `files`, `import`, `migration`, `persistence`; sound dropped |
 | 3 — State (RTK) | ❌ **not done, and deliberately reversed** — see below |
-| 4 — UI | 9 screens; **CostCruncher** is the only one outstanding. Random characters are built — reimagined, not ported (see below) — and roll in both editions from `GenerateDialog` |
+| 4 — UI | 11 screens; **CostCruncher** is the only one outstanding. Random characters are built — reimagined, not ported (see below) — and roll in both editions from `GenerateDialog`. **Authoring** is built across `AuthorCharacterScreen` (the lists) and `AuthorTraitScreen` (one trait's form) |
 | 5 — Migration + parity + release | migration done + device-validated; **releases shipping**; every corpus-triggered bug fixed, cosmetic tail open |
 
 `REBUILD_PLAN.md`'s Progress section has drifted (it still shows Phase 1 unchecked and
@@ -89,6 +96,14 @@ decision unless revisited. One known consequence: the sheet's Alternate Identity
 component-local and resets to on at every mount, where legacy persisted `showSecondary`.
 
 `DiceScreen` consolidates legacy's five Skill/Hit/Damage/Effect/Result screens into one.
+
+**Characters now come from three places, and `origin` is what tells them apart.** An
+`imported` `.hdc` is the player's file and stays read-only. A `generated` one is rebuilt from
+its `recipe`. An `authored` one is rebuilt from its `source` — the `ParsedCharacter` it was
+emitted from, stored in its own column because `data` holds the engine's *output* and that
+does not round-trip. See [`docs/CHARACTER_AUTHORING.md`](docs/CHARACTER_AUTHORING.md); the
+recurring lesson there is **the template is consulted for prices, the trait for everything
+else**, which cost three separate debugging sessions to learn.
 
 **Random characters were reimagined, not ported.** `src/core/random/` (see
 [`docs/RANDOM_CHARACTER.md`](docs/RANDOM_CHARACTER.md)) is clean-room: legacy's

--- a/QA_CHECKLIST.md
+++ b/QA_CHECKLIST.md
@@ -4,7 +4,7 @@ Copyright 2018-Present Philip J. Guinchard — Apache-2.0
 
 # On-device QA shakedown
 
-Manual test plan for a testing build. 1366 unit tests cover the logic; this
+Manual test plan for a testing build. 2216 unit tests cover the logic; this
 covers the integration + native surface they can't (picker, navigation, layout,
 persistence across restarts). **Rebuild first** — the document picker is a new
 native module (`npm run android`).
@@ -148,6 +148,43 @@ native module (`npm run android`).
 - [ ] **Text size** A−/A+ scales the whole UI live; persists.
 - [ ] **Screen animations** off = instant screen transitions.
 
+## Authoring a character (new in 2.8.0)
+- [ ] Characters → **New** opens the form. Name it, set a couple of characteristics, and check
+      the points meter moves as you type.
+- [ ] **Campaign** card: picking a power level changes the total; typing a number the presets
+      don't match flips the picker to **Custom**.
+- [ ] The base-points field is labelled **"Total points"** in 6E and **"Base points"** in 5E —
+      the editions are quoted in different units and the label is the only thing that says so.
+- [ ] Each list (Skills, Perks, Talents, Powers, Martial Arts, Equipment, Complications) shows
+      **one row per trait** with its cost, and tapping a row opens that trait on its own page.
+- [ ] **Add** on any list drops you straight into the new trait's form.
+- [ ] The **Add** field's hint says how many entries are withheld ("N more need a form of their
+      own"). It should never be 0 for Skills or Powers.
+- [ ] A trait's **Remove** deletes it and returns you to the list.
+- [ ] Save is **disabled** while an error is showing, and the errors say what is wrong in words.
+
+## Authoring — the numbers (new in 2.8.0)
+- [ ] A skill taken at **familiarity** costs 1 and rolls **8-**, and does not move when you
+      change the characteristic it would otherwise roll against.
+- [ ] A **Language** priced by fluency: "fluent conversation" 2, "idiomatic" 4.
+- [ ] A **Blast** at 10d6 costs 50. Add **Area Of Effect (Radius)** → active 75. Add an
+      **Obvious Accessible Focus** → real 37. All three numbers visible on the row/meter.
+- [ ] **Resistant Protection**: set 17 rPD / 17 rED → 51 points, and the sheet's PD/ED go up by
+      17 each. (Bought as **equipment** it costs the same and grants **nothing** — the app warns.)
+- [ ] A **Multipower** with a 60 reserve and a 12d6 Blast slot: reserve 60, slot 6.
+- [ ] A **Basic Strike** costs 3 and its damage rises with STR (STR 10 → 4d6, STR 20 → 6d6).
+- [ ] Spend past the allowance → meter reads **"N experience"**, not "over budget", and the
+      saved character's nameplate reads **base + N pts**.
+
+## Authoring — round trip (new in 2.8.0)
+- [ ] Save an authored character → it opens on the sheet, priced, with its points and campaign
+      type on the nameplate.
+- [ ] Re-open it from the sheet's **Edit** → every field is exactly as you left it.
+- [ ] Change one thing, save, re-open → the change stuck and nothing else moved.
+- [ ] Force-quit between saving and re-opening; it survives.
+- [ ] An **imported** `.hdc` still shows **no** edit card. Authoring must never make a file the
+      player owns editable.
+
 ## Migration (if testing over a legacy install)
 - [ ] First launch imported your legacy characters + settings + stats.
 
@@ -164,8 +201,21 @@ native module (`npm run android`).
       Everything else, including every cost, is byte-identical. No fixture in the corpus has one,
       so a real character is the only way to see this.
 
-## Upgrading from 2.4.1 (schema 4 → 7 in one hop — only if a tester skipped 2.5.0)
-- [ ] Every character survives both hops.
+## Upgrading over the previous build (2.8.0: schema 7 → 8)
+- [ ] Install **2.7.1** first. Import a character **that has a Multipower, Elemental Control or
+      VPP** — this is the one that matters. Note its total and the framework's costs.
+- [ ] Install this build over the top → every character is still there, opens, and renders.
+- [ ] **The framework's slots now sit INSIDE it, indented** — where they used to be loose beside
+      an empty container row. That is H2, and it is the fix. 27 of the 37 corpus characters had it.
+- [ ] **The framework's costs are unchanged** — the reserve and every slot. The points were always
+      right; only the arrangement was wrong. A **cost** that moves here is a **regression**.
+- [ ] **No cost moves anywhere else either.** 2.5.0 was the build that changed costs.
+- [ ] Generated characters from 2.7.1 are **still editable** and still their original edition.
+- [ ] Migration 008 is additive (one nullable column), so nothing should need backfilling — but
+      confirm a character saved on 2.7.1 still opens and prices identically.
+
+## Upgrading from 2.4.1 (schema 4 → 8 in one hop — only if a tester skipped 2.5.0)
+- [ ] Every character survives all hops.
 - [ ] The random character rolled on the old build is **still editable** (migration 005
       backfills edit rights from the `generated-` id prefix — that's the only thing carrying
       them over).

--- a/QA_CHECKLIST.md
+++ b/QA_CHECKLIST.md
@@ -148,6 +148,27 @@ native module (`npm run android`).
 - [ ] **Text size** A−/A+ scales the whole UI live; persists.
 - [ ] **Screen animations** off = instant screen transitions.
 
+## Quick Pick (new in 2.8.0 — never shipped to testers before)
+- [ ] **Home** leads with a 3×3 grid. With no pins set, it fills from recently-opened
+      characters, most-recent first, and is useful straight away.
+- [ ] Tapping a slot **makes that character active** and opens their sheet.
+- [ ] On the **character sheet**, a handle sits at the bottom. Tapping it slides the grid up
+      over a dimmed backdrop; tapping the backdrop or the handle again dismisses it.
+- [ ] **Nothing on the sheet hides behind the handle** — scroll to the very bottom and check
+      the last row clears it.
+- [ ] Switching from the sheet **replaces** the character rather than stacking: after hopping
+      through four characters, **one** Back press leaves the sheet.
+- [ ] **Long-press a slot** → picker opens. Choosing a character pins them to that position.
+- [ ] A pinned character **stays put** across app restarts (pins live in Settings).
+- [ ] Pinning someone who was being *suggested* in another slot **moves the suggestion aside** —
+      a character never appears twice in the grid.
+- [ ] Long-pressing a **pinned** slot offers **Remove**; removing it refills from recents.
+- [ ] **Delete a pinned character** (Characters → delete) → its slot empties and refills rather
+      than breaking or showing a ghost.
+- [ ] The picker **does not offer** characters already pinned elsewhere.
+- [ ] **Screen animations off** (Settings) → the sheet snaps open/closed instead of sliding.
+- [ ] Android **back** closes the sheet rather than leaving the screen.
+
 ## Authoring a character (new in 2.8.0)
 - [ ] Characters → **New** opens the form. Name it, set a couple of characteristics, and check
       the points meter moves as you type.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,9 +10,10 @@ listing. Two consequences:
 
 - The release build **must be signed with the legacy app's existing upload key**.
   A brand-new keystore will be **rejected** by Play ("upload key mismatch").
-- `versionCode` must exceed what's live. Legacy shipped **62 / 2.3.0**; **65 / 2.5.0**
-  is out to internal testing, and this repo is set to **67 / 2.7.0**
-  (`android/app/build.gradle`). Bump `versionCode` for every subsequent upload.
+- `versionCode` must exceed what's live. Legacy shipped **62 / 2.3.0**; the last build
+  out is **68 / 2.7.1**, and this repo is set to **69 / 2.8.0**
+  (`android/app/build.gradle`, which carries the full version history in a comment).
+  Bump `versionCode` for every subsequent upload.
 
 ## Signing setup
 
@@ -28,9 +29,16 @@ HEROGMTOOLS_RELEASE_KEY_ALIAS=…
 HEROGMTOOLS_RELEASE_KEY_PASSWORD=…
 ```
 
-Use an **absolute** `STORE_FILE` path (Gradle does not expand `~`). When those
-properties are present, `release` builds sign with them; absent, release falls
-back to debug signing (fine for a local smoke test, rejected by Play).
+Gradle does **not** expand `~`, so `STORE_FILE` is either an absolute path or one
+relative to **`android/app/`** — `storeFile file(...)` resolves against the module
+directory, not the repo root. The build machine currently uses the relative form
+(`hero-mobile.keystore`, i.e. `android/app/hero-mobile.keystore`), which works; checking
+for it from the repo root does not, and looks alarming.
+
+When those properties are present, `release` builds sign with them. **When they are
+absent, release silently falls back to debug signing** — the build succeeds, the `.aab`
+looks fine, and Play rejects it. That is the failure worth guarding against, which is
+what the verification below is for.
 
 ## Build the bundle
 
@@ -40,9 +48,52 @@ cd android
 ./gradlew bundleRelease        # -> app/build/outputs/bundle/release/app-release.aab
 ```
 
-Confirm it's signed with the right key:
+**If you `clean` first, delete `android/app/.cxx` too.** `./gradlew clean` removes the
+generated codegen under `build/` but leaves the CMake/ninja cache in `.cxx`, which still
+references it — the next configure then dies with:
+
+```
+CMake Error ... target_link_libraries):
+  Cannot specify link libraries for target "react_codegen_OPSQLiteSpec"
+  which is not built by this project.
+ninja: error: rebuilding 'build.ninja': subcommand failed
+```
+
+It reads like a broken dependency and isn't; the two caches have just gone out of step.
+
 ```sh
-jarsigner -verify -verbose -certs app/build/outputs/bundle/release/app-release.aab | head
+rm -rf android/app/.cxx android/app/build
+cd android && ./gradlew bundleRelease
+```
+
+A plain `bundleRelease` with no `clean` doesn't hit this. A full rebuild is ~2-3 minutes.
+
+Confirm it's signed with the right key — not just *a* key:
+
+```sh
+AAB=app/build/outputs/bundle/release/app-release.aab
+jarsigner -verify "$AAB"                                    # -> "jar verified."
+jarsigner -verify -verbose -certs "$AAB" | grep -c "Android Debug"   # -> 0
+unzip -p "$AAB" 'META-INF/*.RSA' | keytool -printcert | grep -E 'Owner|SHA1:'
+```
+
+The last one must print the legacy upload key:
+
+```
+Owner: CN=diceless.org, OU=Unknown, O=Diceless, L=Kitchener, ST=Ontario, C=CA
+SHA1: 65:25:E8:AD:77:E2:17:E4:13:24:DA:5F:BD:43:8A:95:23:A2:CA:3C
+```
+
+That fingerprint is what Play matches. `jar verified` alone does **not** distinguish the
+real key from the debug fallback — a debug-signed bundle also verifies.
+
+The version that went in is easiest to read off the merged manifest (the `.aab`'s own
+manifest is protobuf, and `versionName` is a compiled resource, so grepping it finds
+nothing — which is normal, not a problem):
+
+```sh
+grep -oE 'android:version(Code|Name)="[^"]+"' \
+  app/build/intermediates/merged_manifest/release/processReleaseMainManifest/AndroidManifest.xml
 ```
 
 ## Upload to internal testing

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,13 @@ android {
         //            No schema change (END rides the existing blobs), no cost changes.
         // 68/2.7.1 — Accessibility fix: modal dialogs are now readable by screen readers
         //            (VoiceOver/TalkBack). No schema change, no cost changes.
-        versionCode 68
-        versionName "2.7.1"
+        // 69/2.8.0 — Author a character in the app: characteristics, skills, perks, talents,
+        //            powers with advantages/limitations, frameworks, martial arts, equipment
+        //            and complications. Schema 7 → 8 (008, the authoring source).
+        //            Changes no costs — but H2 changes how a framework *renders* on every
+        //            existing character that has one (slots nest instead of sitting loose).
+        versionCode 69
+        versionName "2.8.0"
     }
     signingConfigs {
         debug {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,6 +104,8 @@ android {
         // 69/2.8.0 — Author a character in the app: characteristics, skills, perks, talents,
         //            powers with advantages/limitations, frameworks, martial arts, equipment
         //            and complications. Schema 7 → 8 (008, the authoring source).
+        //            Also carries Quick Pick (PR #48), which landed after 2.7.1 and so has
+        //            never been in a tester build.
         //            Changes no costs — but H2 changes how a framework *renders* on every
         //            existing character that has one (slots nest instead of sitting loose).
         versionCode 69

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -413,6 +413,14 @@ allowance's `base` is its level's *total*, and a 5E one's is its *base* — the 
 The budget lives on the **draft**, not on the screen: a character re-opened at a different
 allowance than it was built to would silently be over or under budget for reasons nobody could see.
 
+**Spending past the allowance is not an overspend — it is experience.** A character who costs more
+than their starting points has earned the difference, which is what experience is in HERO, so the
+meter reads "90 experience" rather than "90 over budget" and the excess is declared as
+`experience` on the character. The sheet's nameplate already prints that beside the base
+(`formatPoints` renders `"400 + 90 pts"`), so nothing needed adding there. The campaign **tier**
+stays keyed on base alone: `powerTier` deliberately does not let a character climb the ladder by
+earning points, and a 400-point character with 250 earned is still Standard Superheroic.
+
 It also closed a gap. `AuthoringProvider` never wrote `basicConfiguration`, so an authored
 character showed neither points nor campaign tier on the sheet's nameplate where a generated or
 imported one does — `pointSummary` reads the declared block and returns null when it is absent.

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -1,0 +1,225 @@
+# Character Authoring — feasibility analysis
+
+> What it would take to author a character sheet inside the app, rather than importing one.
+> Companion to [`RANDOM_CHARACTER.md`](RANDOM_CHARACTER.md) and [`PERSISTENCE.md`](PERSISTENCE.md).
+> **Analysis only — nothing here is built.** Every empirical claim below was measured against
+> the current tree; the probes are quoted inline.
+
+## The headline
+
+**The engine half is already done.** `getCharacter` prices a hand-built character correctly today,
+the full HERO Designer rules catalogue already ships in the binary, and the save path already
+exists. What is missing is an *input* model and the UI over it.
+
+The strongest evidence is that **authoring already happens in this repo, by hand, in production**:
+`core/data/random/powersets.6e.json` is hand-written `.hdc`-shaped trait JSON, and the generator
+runs it through the same engine a real import uses. An authoring feature is that file, made by a
+person tapping a screen instead of by Phil typing JSON.
+
+Per the brief, `.hdc` XML **write-back is out of scope** — the authoring source is stored as JSON in
+the app's own schema, reusing HD's `xmlid`/field vocabulary for consistency. That removes an entire
+XML-writer workstream and the round-trip fidelity problem that comes with it.
+
+## Proof the engine already does its half
+
+A `ParsedCharacter` assembled from scratch (no `.hdc`, no fixture) and run through
+`heroDesignerCharacter.getCharacter()` + `characterTraitDecorator`:
+
+| Authored input | Engine output | Correct? |
+|---|---|---|
+| `STR` 20 levels, 6E Superheroic | value 30, cost 20 | ✅ |
+| Blast 10 levels + `AOE` Radius 8m | base 50, **active 75**, real 75 | ✅ 50 × 1.5 |
+| `ACROBATICS`, 0 levels | cost 3, roll `11-` | ✅ DEX 10 → 11- |
+| `ACROBATICS` +2 levels, named "Tumbling" | cost 7, label `Tumbling (Acrobatics)` | ✅ |
+| Psych Complication + `SITUATION` Common + `INTENSITY` Strong | cost 20 | ✅ 10 + 10 |
+
+Nothing had to change in `core/` to get those numbers. The pricing, rolls, labels, advantage
+multipliers and adder summation all work on hand-built input.
+
+## What already exists
+
+| Asset | Where | Note |
+|---|---|---|
+| Rules catalogue, both editions | `core/data/herodesigner/` (1.2 MB) | **477** authorable entries in 5E, **409** in 6E |
+| Form metadata for those entries | same | see below — HD's own UI hints ship with the data |
+| Trait pricing for every family | `core/traits/` | 66 decorators, 37 of them power-specific |
+| Hand-authored trait JSON, proven | `core/data/random/*.json` | the authoring data model, already in production |
+| Build → price → save pipeline | `GenerateProvider.keep` / `.revise` | `getCharacter` → `characters.save({origin, recipe})` |
+| Editable-vs-read-only provenance | migration 005 (`origin`, `recipe`) | imports stay read-only; the gate already exists |
+| Cost summation primitive | `allocate.ts` `skillsBudget` | sums decorated `realCost()` per category |
+| Form controls | `app/components/` | `TextField`, `NumberField`, `SelectField`, `SegmentedControl` |
+
+### The templates already carry HD's form metadata
+
+This is the single biggest lever, and it is easy to miss. The `.hdt` entries are not just costs —
+they are the field definitions HERO Designer builds *its* dialogs from. Counting 6E only:
+
+```
+option=61  adder=92  inputlabel=49  minval=75  levelstart=75
+mincost=102  maxcost=29  maxval=5  optionlabel=6  levelslabel=2
+exclusive / excludes  (adder mutual-exclusion, e.g. PLUSONEPIP vs PLUSONEHALFDIE)
+```
+
+`AOE` alone declares five `option`s (Radius/Cone/Line/Surface/Any), each with its own
+`lvlmultiplier` and its own nested adders, plus four shared adders with exclusion rules. A
+generic renderer over this metadata gets you most of the authoring UI for free, in both editions,
+with no per-power code.
+
+**But not all of it.** The ~37 power decorators read fields the templates never declare —
+`pdlevels`/`edlevels` (Resistant Protection), `ultraSlot`, `input`, `optionid`. Those need a
+hand-written field map per power family. That long tail is the honest bulk of the UI work.
+
+## What's missing
+
+### 1. Persistence must store the authoring *source*
+
+The stored `document` is `getCharacter`'s **output**, not its input. Re-opening an editor needs the
+input back, and the output does not round-trip:
+`populateMovementAndCharacteristics` keeps exactly nine fields per characteristic
+(`type, name, shortName, value, cost, base, definition, roll, ncm`) and discards the parsed entry —
+so any adder or modifier on a characteristic is gone. Levels are recoverable (`value − base`);
+everything else is not.
+
+Generated characters already dodge this by storing the **recipe** in its own column and rebuilding.
+Authored characters need the same move, one level lower: store the `ParsedCharacter` itself.
+
+```sql
+-- migration 008
+ALTER TABLE characters ADD COLUMN source TEXT;   -- ParsedCharacter JSON; NULL for imports
+-- origin gains a third value: 'imported' | 'generated' | 'authored'
+```
+
+`origin: 'authored'` slots straight into the existing editability gate (`editableRecipe`'s pattern).
+Note the interchange consequence: an authored character shared as `.hsmc` would carry the document
+but not the source, so it would arrive read-only. That is defensible (it matches how an import
+behaves) but should be a decision, not an accident. *(No `.hsmc` export is implemented today.)*
+
+### 2. A `ParsedCharacter` emitter — `core/authoring/`
+
+Pure core, no RN, mirroring `core/random/`'s discipline. This is where the real work is, and it has
+to synthesize several things the engine consumes but does **not** derive. Each of these was hit
+empirically:
+
+- **`alias` and `optionAlias` are author-supplied display strings.** The engine reads them
+  (`modifiers/modifier.ts:99`, `characterTrait.ts:101`, `skillLevels.ts:36`) and never derives them
+  from the template. The generator's authored JSON writes them by hand. An authoring UI must
+  synthesize them from the template's `display` plus the selected option.
+- **`name: null` is required, not optional.** A trait with `name` *absent* renders its label as the
+  literal string `"undefined (Acrobatics)"`. The `.hdc` parser supplies it via xml2js
+  `emptyTag: null`; a hand-built object has to do it deliberately.
+- **Every trait category key must be present.** `powers: {...}` with `perks` merely `undefined`
+  throws `Cannot read properties of undefined (reading 'perk')` in `populateTrait` — the function
+  guards `null` but not `undefined`. All seven categories must be emitted, `null` when empty.
+- **Frameworks are identified by their sub-key, not their xmlid.** A Multipower is
+  `XMLID="GENERIC_OBJECT"` under a `multipower` sub-key; `normalizeCharacterItems` turns the sub-key
+  into `originalType`. Emitting `xmlid: 'MULTIPOWER'` produces a container the engine does not
+  recognise.
+- Stable `id`s, `position` ordering, and `parentid` wiring for framework slots.
+
+### 3. Validation the engine does not perform
+
+`getCharacter` prices; it does not judge legality. Two silent failure modes, both already documented
+as having shipped bugs, and both confirmed here:
+
+- **An xmlid the edition lacks resolves to no template and prices at 0**, reading as authored.
+  `LACKOFWEAKNESS`, `SEDUCTION`, `AREA_KNOWLEDGE`, `LIGHTNING_REFLEXES_SINGLE` all did this. In the
+  app it is worse than silent: a bogus xmlid makes the decorator *throw*, and
+  `characterSheet.ts` catches it and emits a stub row at cost 0. **A typo becomes a free power.**
+- **NCM has a hardcoded `basecost` with no template in either edition**, so template guards miss it.
+
+An authoring UI is a machine for generating exactly these inputs, so it needs a real validator:
+xmlid resolves *in this character's edition*; required `option`/`input` supplied; adder
+`exclusive`/`excludes` respected; `minval`/`maxval`/`mincost`/`maxcost` enforced; framework pool
+not overspent. **This is a new concern with no existing home** — nothing in `core/` validates today,
+because a `.hdc` from HERO Designer was already legal by construction.
+
+### 4. A live points total
+
+There isn't one. `characterPoints.ts` reads only the **declared** `basicConfiguration` a `.hdc`
+carries — it never sums what the character actually costs. `allocate.ts` has the only summation, and
+it iterates each category **top-level only**, which (see below) under-counts anything nested.
+
+Authoring needs a real `spent()` over flattened traits + characteristic costs, split by bucket, with
+complications counted against the edition's limit. Modest work, but it does not exist.
+
+## A blocker found while probing: H2 was worse than the ledger said — ✅ now fixed
+
+> **Resolved.** Phase 0 is done: the comparator is numeric, callers descend, and the hero golden
+> master is re-based to normalize arrangement only. See `H2` in
+> [`KNOWN_DEVIATIONS.md`](KNOWN_DEVIATIONS.md). The analysis below is kept as the record of what was
+> found and why it mattered.
+
+
+`KNOWN_DEVIATIONS.md` lists **H2** — `populateTrait`'s `.sort((a, b) => Number(a.position > b.position))` —
+as affecting display order, and says *"point totals are order-independent"*. That undersells it.
+
+The comparator never returns a negative, so nothing can move earlier in the array. Framework
+containers arrive appended last (`normalizeCharacterItems` moves every non-`power` sub-key to the end
+of the `power` array), so **the container is processed after its own slots**. When a slot looks up its
+parent, the parent is not in `character[traitKey]` yet, and the slot is pushed to top level instead of
+nesting.
+
+Measured across the 37-fixture corpus:
+
+| | shipped comparator | `a.position - b.position` |
+|---|---|---|
+| Fixtures with orphaned framework slots | **27** | **0** |
+| greyman's Multipower | index 9, **0 children** | index 3, **4 children** |
+| m-championsmush | 148 orphaned slots, 54 empty containers | 0 |
+
+**Costs are unaffected**, which is why this has hidden for so long: `getParent`
+(`characterTrait.ts:201`) resolves a parent by scanning `character[listKey]` for `id === parentid`,
+and the orphaned container is still sitting at top level. So the Skill Enhancer discount (H12) and
+framework slot pricing both still work.
+
+The **visible** effect is on the sheet. `buildCharacterSheet` indents rows by descending
+`item.powers` (`depth`), so today every Multipower, Elemental Control and VPP renders as an empty
+container row with its slots flattened out beside it rather than nested under it.
+
+**Why this blocks authoring:** frameworks are a core authoring feature, and an authoring UI would
+build them nested-first. It would hit this immediately and look broken.
+
+**Cost of fixing it:** with the numeric comparator, 60 tests across 8 suites fail. Most are golden
+masters — expected, and exactly what the ledger's three-step process is for (re-base as an
+intentional divergence). But **one failure is substantive**: `generateRandomCharacter spends exactly
+its powers budget` drops 125 → 60 for Metamorph, because `allocate.ts` sums top-level only and the
+now-nested slots vanish from its reduce. So the fix is:
+
+1. numeric comparator,
+2. **flatten the summations in `core/random`** (`allocate.ts`, `ruleOfXStats.ts`),
+3. re-base the affected golden masters per the ledger.
+
+That is a well-scoped change, but it is a prerequisite, not a side quest — and it is worth doing on
+its own merits regardless of whether authoring ships.
+
+## Suggested phasing
+
+Each phase is independently shippable and leaves the app coherent.
+
+| Phase | Scope | Notes |
+|---|---|---|
+| **0** | ✅ **done** — fix H2, teach callers to descend, re-base | Prerequisite for frameworks; stood alone |
+| **A** | `core/authoring` emitter, migration 008, `origin: 'authored'`, live points total, characteristics + complications | Delivers a saveable, priced, editable character |
+| **B** | Skills / perks / talents from the catalogue, template-driven forms | The generic renderer earns its keep here |
+| **C** | Powers: levels, options, adders, **modifiers** | The big one — advantages/limitations, and the per-power field long tail |
+| **D** | Frameworks (Multipower / EC / VPP) | Needs Phase 0 |
+| **E** | Martial arts, equipment | 56 maneuvers per edition, largely table-driven |
+
+Rough shape: **~2.5–4k lines**, against an 18.4k-line codebase — so a substantial feature, comparable
+to `core/random/` plus its UI, but with a much larger share of it generic and data-driven.
+
+## Risks worth naming up front
+
+1. **The validator is the quality bar, not the forms.** The forms are mostly generated. What
+   determines whether this feature is trustworthy is whether it refuses to emit a character the
+   engine will silently price at 0. Build the validator alongside the emitter, not after.
+2. **Edition confusion.** `RANDOM_CHARACTER.md` records this biting twice, and it is worse here:
+   authoring exposes *all* 477/409 entries, and the two editions share many xmlids with different
+   costs. Never let a lookup default its edition.
+3. **The golden masters do not cover authoring.** They prove parity on 37 imported files. A
+   hand-built character is new input shape, and the corpus says nothing about it — the generator
+   found H9 and H10 precisely because building characters exercises paths importing never did.
+   Expect authoring to find more, and treat that as the feature working.
+4. **`characterSheet.ts:333`'s try/catch will mask emitter bugs.** A malformed authored trait
+   degrades to a cost-0 stub row rather than an error. Build the sheet and read the values when
+   verifying; don't just check that nothing threw.

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -394,6 +394,30 @@ changing it is a correctness-pass decision with a rules question attached (is ca
 default?), not something an authoring layer should quietly paper over. What authoring does instead
 is **warn**, so a player sees it rather than discovering it in play.
 
+## The campaign allowance
+
+A character declares what it was built on, and the player picks it.
+
+`POINT_ALLOWANCES` is derived from `core/random`'s `POWER_LEVELS` rather than restating those
+numbers — they are already checked against both rulebooks, and a second copy is how the legacy
+`skillsets.json` came to disagree with itself about what a profession cost. The presets sit over
+two plain numbers, so a GM running a campaign the rulebooks have no name for can still say what it
+allows; the picker reads "Custom" whenever the numbers match no level, derived rather than stored,
+so it cannot claim a level the numbers do not match.
+
+**The editions are quoted in different units, and the field labels say so.** 5E quotes a base that
+disadvantages then add to; 6E quotes the whole allowance and complications grant nothing. So a 6E
+allowance's `base` is its level's *total*, and a 5E one's is its *base* — the same conversion
+`declaredConfiguration` makes. Getting it backwards is the easiest mistake available here.
+
+The budget lives on the **draft**, not on the screen: a character re-opened at a different
+allowance than it was built to would silently be over or under budget for reasons nobody could see.
+
+It also closed a gap. `AuthoringProvider` never wrote `basicConfiguration`, so an authored
+character showed neither points nor campaign tier on the sheet's nameplate where a generated or
+imported one does — `pointSummary` reads the declared block and returns null when it is absent.
+The chosen allowance is now what gets declared.
+
 ## Risks worth naming up front
 
 1. **The validator is the quality bar, not the forms.** Borne out in Phase A: the forms were a

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -200,7 +200,7 @@ Each phase is independently shippable and leaves the app coherent.
 |---|---|---|
 | **0** | ✅ **done** — fix H2, teach callers to descend, re-base | Prerequisite for frameworks; stood alone |
 | **A** | ✅ **done** — `core/authoring` emitter, migration 008, `origin: 'authored'`, live points total, characteristics + complications | Delivers a saveable, priced, editable character |
-| **B** | Skills / perks / talents from the catalogue, template-driven forms | The generic renderer earns its keep here |
+| **B** | ✅ **done** — skills / perks / talents from the catalogue, one generic renderer | The generic renderer earns its keep here |
 | **C** | Powers: levels, options, adders, **modifiers** | The big one — advantages/limitations, and the per-power field long tail |
 | **D** | Frameworks (Multipower / EC / VPP) | Needs Phase 0 |
 | **E** | Martial arts, equipment | 56 maneuvers per edition, largely table-driven |
@@ -241,6 +241,43 @@ reimplemented. Same trick `core/random/characteristics` uses.
 scanning both templates), so it is detected from the data rather than hardcoded, but it is **not a
 general mechanism** and should not become one. Expect a handful more of these per phase; that is
 the per-family long tail, and it is the honest cost of the feature.
+
+## What Phase B actually built
+
+**One renderer for four categories.** Skills, perks, talents and complications differ in which
+fields their template entries declare, not in kind, so `TraitSection`/`TraitRow` draw whatever the
+catalogue reports and nothing in the screen names a specific trait. Adding Phase B's three
+categories added no per-trait UI code at all.
+
+`AuthoredTrait` is one shape for all four, gaining `characteristic`, `option` and `familiarity`
+alongside Phase A's `input`/`levels`/`adders`. `CatalogueTrait` likewise.
+
+**Coverage, stated rather than silent.** `authorable()` is what the UI offers; `withheld()` is what
+it does not, and the "Add" field shows the count. In 6E that is 59 of 68 skills, 9 of 13 perks and
+22 of 24 talents. The withheld ones are traits whose decorators read fields no template declares —
+Weapon Familiarity's category/member split, Transport Familiarity's nested adder tree, Autofire
+Skills' per-skill list. Shrinking `BESPOKE` is a later phase, one decorator at a time.
+
+**Two things the engine needed that the template alone doesn't give you:**
+
+- **`basecost` must be copied onto the trait.** `CharacterTrait.cost()` reads the *trait's*
+  basecost and never the template's — the template is consulted for per-level prices only. A
+  3-point Talent emitted without it prices at 0 and still renders. Found by building one.
+- **`levels` must always be emitted as a number.** `Roll` computes `base + trait.levels` unguarded,
+  so an absent `levels` prints `NaN-` rather than failing.
+
+**A skill has three ways to be priced, and picking the wrong one costs nothing rather than
+failing**: by characteristic (`characteristicChoice`), by familiarity (a flat 8- for a point), or
+by a chosen option (a Language's fluency, a Skill Level's breadth). The validator treats a missing
+characteristic as an error for exactly that reason, and the test that says so is paired with a
+build showing the same skill priced at 0.
+
+**`normalizedTemplate` is new on `core/hero`.** An entry's xmlid is often *derived* from the sub-key
+it sits under (`knowledgeSkill` → `KNOWLEDGE_SKILL`), and deriving it a second time in the
+catalogue is how you end up offering a trait the engine cannot match. It also documents a legacy
+quirk worth knowing: normalization concatenates the entries it collected onto the array they partly
+came from, so every plainly-declared skill appears **twice**. Harmless to the engine, which only
+ever looks one up by xmlid; a catalogue has to de-duplicate.
 
 ## Risks worth naming up front
 

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -201,7 +201,7 @@ Each phase is independently shippable and leaves the app coherent.
 | **0** | ✅ **done** — fix H2, teach callers to descend, re-base | Prerequisite for frameworks; stood alone |
 | **A** | ✅ **done** — `core/authoring` emitter, migration 008, `origin: 'authored'`, live points total, characteristics + complications | Delivers a saveable, priced, editable character |
 | **B** | ✅ **done** — skills / perks / talents from the catalogue, one generic renderer | The generic renderer earns its keep here |
-| **C** | Powers: levels, options, adders, **modifiers** | The big one — advantages/limitations, and the per-power field long tail |
+| **C** | ✅ **done** — powers, advantages/limitations, and the first field group | The big one — and the per-power long tail is now a named, countable list |
 | **D** | Frameworks (Multipower / EC / VPP) | Needs Phase 0 |
 | **E** | Martial arts, equipment | 56 maneuvers per edition, largely table-driven |
 
@@ -278,6 +278,48 @@ catalogue is how you end up offering a trait the engine cannot match. It also do
 quirk worth knowing: normalization concatenates the entries it collected onto the array they partly
 came from, so every plainly-declared skill appears **twice**. Harmless to the engine, which only
 ever looks one up by xmlid; a catalogue has to de-duplicate.
+
+## What Phase C actually built
+
+**Modifiers are the headline, and they needed no new pricing code.** `ModifierCalculator` already
+defines `activeCost = cost x (1 + sum advantages)` and `realCost = activeCost / (1 - sum
+limitations)`; Phase C just had to emit modifiers the engine recognises. A Blast with Area Of
+Effect and an Obvious Accessible Focus comes out `base 50 / active 75 / real 37`, and all three are
+pinned, because they answer different questions.
+
+**Nothing records whether a modifier is an advantage or a limitation** — the sign of its computed
+cost decides, and `ModifierCalculator` splits on exactly that. An option can flip a modifier from
+one to the other, so a stored flag could disagree with the rules. The UI shows one list for the
+same reason.
+
+**Modifiers have their own adders, one level deep.** Area Of Effect is the everyday case: a Radius
+*and* a Selective/Explosion/Mobile adder that changes what it costs. Without nested adders in the
+catalogue an AOE silently prices as its bare option.
+
+### The per-power long tail, made countable
+
+The analysis warned that ~37 power decorators read fields no template declares. That turned out to
+be **five** decorators in practice (`barrier`, `duplication`, `enduranceReserve`, `flash`,
+`senseAffectingPower`) plus Resistant Protection, whose fields are read by the *character-level*
+defence queries rather than by a power decorator at all.
+
+Resistant Protection got a declared **field group** rather than being withheld, because it is the
+most-taken defensive power in the corpus and the failure is invisible: emitted without
+`pdlevels`/`edlevels`/`mdlevels`/`powdlevels` it costs full price and grants **no defence**. The
+`.hdc` also carries a `levels` total, and across all 37 corpus characters that total is always the
+sum of the four — so the emitter derives it rather than asking twice.
+
+Everything else stays in `BESPOKE`, which is now a named list with a reason attached rather than a
+vague warning. **6E offers 74 of 101 powers, 5E 79 of 102.** The withheld ones are the five
+decorator cases, the framework/container powers (Phase D), and the sense-enhancements that state no
+cost because they belong to a sense rather than to a sheet.
+
+### A bug worth remembering
+
+`asArray(entry.adder).map(adderOf)` — `Array.prototype.map` passes the **index** as the second
+argument, which landed in `adderOf`'s `depth` parameter and read as "you are already nested" for
+every adder but the first. Nested adders silently vanished. The signature is now `depth: 0 | 1` and
+the comment says why; a default parameter that means something is a trap next to `.map`.
 
 ## Risks worth naming up front
 

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -202,7 +202,7 @@ Each phase is independently shippable and leaves the app coherent.
 | **A** | ✅ **done** — `core/authoring` emitter, migration 008, `origin: 'authored'`, live points total, characteristics + complications | Delivers a saveable, priced, editable character |
 | **B** | ✅ **done** — skills / perks / talents from the catalogue, one generic renderer | The generic renderer earns its keep here |
 | **C** | ✅ **done** — powers, advantages/limitations, and the first field group | The big one — and the per-power long tail is now a named, countable list |
-| **D** | Frameworks (Multipower / EC / VPP) | Needs Phase 0 |
+| **D** | ✅ **done** — Multipower, Elemental Control, VPP | Needed Phase 0, and proved it |
 | **E** | Martial arts, equipment | 56 maneuvers per edition, largely table-driven |
 
 Rough shape: **~2.5–4k lines**, against an 18.4k-line codebase — so a substantial feature, comparable
@@ -320,6 +320,45 @@ cost because they belong to a sense rather than to a sheet.
 argument, which landed in `adderOf`'s `depth` parameter and read as "you are already nested" for
 every adder but the first. Nested adders silently vanished. The signature is now `depth: 0 | 1` and
 the comment says why; a default parameter that means something is a trap next to `.map`.
+
+## What Phase D actually built
+
+**This is the phase Phase 0 was for.** Before H2 was fixed a framework container was processed
+*after* its own slots and never adopted them — the slots landed at the top level and the container
+came out empty. An authoring UI would have produced exactly that, immediately, and looked broken.
+`frameworks.test.ts` asserts the nesting explicitly, so it is a regression test for H2 as much as a
+test of frameworks.
+
+**A framework's identity is the sub-key it is emitted under, not its xmlid.** All three containers
+are `GENERIC_OBJECT`; `normalizeCharacterItems` copies the sub-key onto the container as
+`originalType`, and `isPowerFrameworkItem` matches on that to decide how a slot is priced. So
+`FrameworkKind`'s three strings — `multipower`, `elementalControl`, `vpp` — are load-bearing
+spelling, and getting one wrong yields a container that parses fine and slots that cost full price.
+
+The three kinds price slots differently, which is the whole reason they exist:
+
+| Kind | Container | Slot |
+|---|---|---|
+| Multipower | reserve as `basecost` | active ÷ 10 (fixed slot) |
+| Elemental Control | reserve as `basecost` | active − reserve |
+| Variable Power Pool | pool as **`levels`** | — |
+
+The VPP is the odd one: it states its size in `levels` where the other two use `basecost`, and
+`VariablePowerPool.cost()` reads it accordingly. A 50-point pool costs 75 — the pool plus a control
+cost of half of it.
+
+### A second latent engine bug, found the same way as H2
+
+`MultipowerItem` reads `ultraSlot` off the **`CharacterTrait` wrapper** rather than off the trait,
+behind a cast that stops the compiler objecting. The wrapper has no such field, so the read is
+always `undefined` and **every Multipower slot divides by 10** whatever kind of slot it is.
+Confirmed by pricing the same authored slot both ways: 6 either way.
+
+Not corpus-triggered — all 37 fixtures use fixed slots exclusively, and for a fixed slot ÷10 is
+right — so no golden master can see it. Recorded as **H13**; not fixed here, because that is a
+correctness-pass change with its own commit, its own rules check and its own test. The consequence
+for authoring is that `core/authoring` emits **fixed slots only** and the UI says so, rather than
+offering a variable slot that would silently price as a fixed one.
 
 ## Risks worth naming up front
 

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -2,8 +2,8 @@
 
 > What it would take to author a character sheet inside the app, rather than importing one.
 > Companion to [`RANDOM_CHARACTER.md`](RANDOM_CHARACTER.md) and [`PERSISTENCE.md`](PERSISTENCE.md).
-> **Analysis only — nothing here is built.** Every empirical claim below was measured against
-> the current tree; the probes are quoted inline.
+> **Phase 0 and Phase A are built** (see the phasing table); the rest is still analysis. Every
+> empirical claim below was measured against the tree, not read off the code.
 
 ## The headline
 
@@ -199,7 +199,7 @@ Each phase is independently shippable and leaves the app coherent.
 | Phase | Scope | Notes |
 |---|---|---|
 | **0** | ✅ **done** — fix H2, teach callers to descend, re-base | Prerequisite for frameworks; stood alone |
-| **A** | `core/authoring` emitter, migration 008, `origin: 'authored'`, live points total, characteristics + complications | Delivers a saveable, priced, editable character |
+| **A** | ✅ **done** — `core/authoring` emitter, migration 008, `origin: 'authored'`, live points total, characteristics + complications | Delivers a saveable, priced, editable character |
 | **B** | Skills / perks / talents from the catalogue, template-driven forms | The generic renderer earns its keep here |
 | **C** | Powers: levels, options, adders, **modifiers** | The big one — advantages/limitations, and the per-power field long tail |
 | **D** | Frameworks (Multipower / EC / VPP) | Needs Phase 0 |
@@ -208,11 +208,46 @@ Each phase is independently shippable and leaves the app coherent.
 Rough shape: **~2.5–4k lines**, against an 18.4k-line codebase — so a substantial feature, comparable
 to `core/random/` plus its UI, but with a much larger share of it generic and data-driven.
 
+## What Phase A actually built
+
+`core/authoring/` — pure core, five modules:
+
+| Module | Does |
+|---|---|
+| `types` | the **draft**: what the player chose, by xmlid, with no engine boilerplate |
+| `catalogue` | reads the `.hdt` form metadata — the only place that touches templates |
+| `emit` | draft → `ParsedCharacter`, satisfying the four parser habits below |
+| `spend` | what it costs, asked of the engine; the 5E/6E complication fork |
+| `source` | the stored-draft round trip, failing safe like `parseRecipe` |
+
+Plus migration 008 (`source` column), `origin: 'authored'`, `AuthoringProvider`, and
+`AuthorCharacterScreen`. 44 new tests.
+
+**The four habits the emitter had to learn**, each found by running the engine rather than reading
+it, and each failing quietly:
+
+1. all seven trait categories present — `populateTrait` guards `null` but not `undefined`
+2. `name: null`, not absent — absent renders the literal string `"undefined (…)"`
+3. `alias`/`optionAlias` copied from the template's `display` — the engine prints them, never derives them
+4. ids derived from position, so the same draft always emits the same document
+
+**Characteristics are stated as totals** and converted by probing the engine at zero, so 5E's
+figured characteristics (ED from CON, STUN from BODY+STR+CON) stay golden-mastered rather than
+reimplemented. Same trick `core/random/characteristics` uses.
+
+**One genuine special case surfaced: Rivalry.** Its description is a free-text adder whose
+`optionAlias` carries the player's words behind an opening bracket — which is why
+`Complication.label()` does `.slice(1)`. It is the only such adder in either edition (verified by
+scanning both templates), so it is detected from the data rather than hardcoded, but it is **not a
+general mechanism** and should not become one. Expect a handful more of these per phase; that is
+the per-family long tail, and it is the honest cost of the feature.
+
 ## Risks worth naming up front
 
-1. **The validator is the quality bar, not the forms.** The forms are mostly generated. What
-   determines whether this feature is trustworthy is whether it refuses to emit a character the
-   engine will silently price at 0. Build the validator alongside the emitter, not after.
+1. **The validator is the quality bar, not the forms.** Borne out in Phase A: the forms were a
+   an afternoon, and every interesting bug was a legality question. Each error case in
+   `validate.test.ts` is paired with a demonstration of the silent failure it prevents — keep that
+   discipline, because a validator with no such pairing is untested by construction.
 2. **Edition confusion.** `RANDOM_CHARACTER.md` records this biting twice, and it is worse here:
    authoring exposes *all* 477/409 entries, and the two editions share many xmlids with different
    costs. Never let a lookup default its edition.

--- a/docs/CHARACTER_AUTHORING.md
+++ b/docs/CHARACTER_AUTHORING.md
@@ -203,7 +203,7 @@ Each phase is independently shippable and leaves the app coherent.
 | **B** | ✅ **done** — skills / perks / talents from the catalogue, one generic renderer | The generic renderer earns its keep here |
 | **C** | ✅ **done** — powers, advantages/limitations, and the first field group | The big one — and the per-power long tail is now a named, countable list |
 | **D** | ✅ **done** — Multipower, Elemental Control, VPP | Needed Phase 0, and proved it |
-| **E** | Martial arts, equipment | 56 maneuvers per edition, largely table-driven |
+| **E** | ✅ **done** — martial arts, equipment | 56 maneuvers per edition, largely table-driven |
 
 Rough shape: **~2.5–4k lines**, against an 18.4k-line codebase — so a substantial feature, comparable
 to `core/random/` plus its UI, but with a much larger share of it generic and data-driven.
@@ -359,6 +359,40 @@ right — so no golden master can see it. Recorded as **H13**; not fixed here, b
 correctness-pass change with its own commit, its own rules check and its own test. The consequence
 for authoring is that `core/authoring` emits **fixed slots only** and the UI says so, rather than
 offering a variable slot that would silently price as a fixed one.
+
+## What Phase E actually built
+
+**Maneuvers are the only catalogue entry with no xmlid at all.** The template states a `display`
+and nothing else to identify it; `normalizeTemplateItem` derives `BASIC_STRIKE` from
+`"Basic Strike"`. The emitter therefore writes `xmlid: 'MANEUVER'` plus a `display`, exactly as
+HERO Designer does, and lets the engine derive the real one — so that rule lives in one place, and
+it is the same place the template lookup uses.
+
+**A maneuver's combat line is copied onto the trait**, because `Maneuver` reads every part of it
+(`ocv`, `dcv`, `dc`, `phase`, `effect`, `addstr`, `category`, `weaponeffect`) off the *trait* rather
+than the template — a real `.hdc` writes it out per maneuver. Emitted without it, a maneuver prices
+correctly and renders with no OCV, no DCV and no effect. Same shape as Phase B's `basecost`, and
+the third time this pattern has come up: **the template is consulted for prices, the trait for
+everything else.**
+
+55 of 56 maneuvers are offered in both editions; `WEAPON_ELEMENT` is withheld because it wants a
+list of the weapons a style covers, which no template describes.
+
+**Equipment is powers in a different bucket** — same catalogue, same modifiers, same field groups,
+because `populateTrait` is called with `('equipment', 'powers', 'power')` and resolves items against
+the powers templates. It needed no new machinery, only a second draft list.
+
+### A limitation worth knowing about, found by testing it
+
+**Equipment never contributes to a character's totals.** `powersForTotals` reads `character.powers`,
+and nothing in the engine reads `character.equipment` at all. So a Resistant Protection bought as
+equipment costs its points, shows its defences on the row, and adds **nothing** to PD/ED — where
+the identical power bought innately adds 4.
+
+That is faithful to legacy and the golden masters agree, so it is pinned rather than worked around:
+changing it is a correctness-pass decision with a rules question attached (is carried gear "on" by
+default?), not something an authoring layer should quietly paper over. What authoring does instead
+is **warn**, so a player sees it rather than discovering it in play.
 
 ## Risks worth naming up front
 

--- a/docs/KNOWN_DEVIATIONS.md
+++ b/docs/KNOWN_DEVIATIONS.md
@@ -38,7 +38,7 @@
 | T3 | `mainapp` overlays ignored | needs rules check | no model impact | none |
 | T4 | Item-add into a missing base sub-key → `[undefined, item]` | real bug (edge) | unknown / no | templates |
 | H1 | `character.template` always `undefined` | cosmetic | yes | hero |
-| H2 | Trait sort uses a boolean-returning comparator | real bug | likely (trait order) | hero |
+| H2 | Trait sort uses a boolean-returning comparator, so frameworks lose their slots | ✅ **fixed** — was real bug, active | **yes — 27 fixtures** | hero (re-based) |
 | H3 | Char/defense totals skip **duplicate** powers | ✅ **fixed** — was real bug, active | yes — junkyard, mark-li-v5a-433 | hero query (re-based) |
 | H4 | `Maneuver.roll()` crashes on an unresolved-template maneuver | ✅ **fixed** — was real bug, active | yes — tazimmaad ("Cut") | traits (decorator, re-based) |
 | H5 | VPP contents counted toward totals | ✅ **fixed** — was real bug, active | yes — adamantine (Leaping), m-championsmush | hero query / movement |
@@ -118,18 +118,51 @@
 - **Fix + verify:** choose the correct value; hero unit test; re-base hero golden
   master.
 
-## H2 — Trait sort uses a boolean-returning comparator
+## H2 — Trait sort uses a boolean-returning comparator — ✅ FIXED
+
+**Fixed.** The comparator is now `.sort((a, b) => a.position - b.position)`.
 
 - **Where:** `populateTrait` — `.sort((a, b) => Number(a.position > b.position))`
   (legacy returns the raw boolean; V8 coerces to 0/1). Never returns a negative, so
-  it is not a correct comparator — a partial/incorrect ordering.
+  it is not a correct comparator: nothing can move earlier in the array, which makes
+  the sort a no-op on anything already out of order.
 - **Legacy:** same.
-- **Correct:** `.sort((a, b) => a.position - b.position)`.
-- **Corpus impact:** likely changes trait **order** for some characters (affects
-  display order and any position-indexed logic; point totals are order-independent).
-  Confirm which fixtures reorder.
-- **Fix + verify:** proper numeric comparator; unit test with shuffled positions;
-  re-base hero golden master for reordered characters.
+
+**This entry previously read "affects display order; point totals are
+order-independent". That was wrong about the scope, and right about the totals.**
+The ordering and the *structure* are the same problem:
+
+`normalizeCharacterItems` moves every non-`power` sub-key — `<MULTIPOWER>`,
+`<ELEMENTALCONTROL>`, `<VPP>`, `<LINGUIST>` — onto the **end** of its category's
+list, whatever its `POSITION` says. `populateTrait` then attaches each slot by
+looking its `parentid` up in `character[traitKey]`. With the container still
+unprocessed the lookup misses, and the slot is pushed to the **top level** instead
+of nesting. So every framework came out as an empty container with its slots
+scattered beside it.
+
+- **Corpus impact:** **27 of 37 fixtures** had at least one orphaned slot —
+  `m-championsmush` alone had 148 across powers and skills, and 54 empty containers.
+  `greyman`'s Multipower held 0 of its 4 slots. After the fix: zero orphans, corpus-wide.
+- **Costs did not move, anywhere.** `getParent` (`characterTrait.ts`) resolves a
+  parent by scanning `character[listKey]` for the id, and the container sits there
+  either way — which is why the Skill Enhancer discount (H12) and framework slot
+  pricing went on working for years while the nesting was broken. The decorator and
+  query golden masters were **not** re-based for H2, because nothing in them changed.
+- **What users see:** the sheet indents by descending the child array, so every
+  Multipower, Elemental Control and VPP previously rendered as an empty container
+  row with its slots flattened out beside it. They now nest.
+- **Fix + verify:** numeric comparator; `hero/__tests__/traitSort.test.ts` pins
+  ascending order, framework/enhancer nesting, zero orphans corpus-wide, and that the
+  affected costs are unchanged; hero golden master re-based to normalize **arrangement
+  only** (see `canonical` there) so all 37 fixtures still compare in full.
+
+**Callers had to learn to descend.** Anything summing or scanning a trait list
+top-level-only would now under-read. `withDescendants` (`core/util`) and
+`TRAIT_CHILD_KEYS` (`core/hero`) were added for this, and the child key is **not
+`powers` for most categories** — a Skill Enhancer nests under `skills`, a martial
+style under `maneuver`, equipment under both `power` and `powers`. Updated:
+`allocate.skillsBudget`, `ruleOfXStats`, and `characterSheet` (rows, alternate-ID
+filter, alternate-ID scan).
 
 ## H3 — Characteristic/defense totals skip duplicate powers — ✅ FIXED
 

--- a/docs/KNOWN_DEVIATIONS.md
+++ b/docs/KNOWN_DEVIATIONS.md
@@ -49,6 +49,7 @@
 | H10 | `Clinging.cost()` adds a stray `+1` | ✅ **fixed** — was real bug, active | yes — mark-li, aoe, spyder2022 | traits (decorator, re-based) |
 | H11 | `HandToHandAttack.roll()` computes a half-die then drops it | ✅ **fixed** — was real bug (latent) | no — the corpus never reaches the branch | none (no re-base needed) |
 | H12 | Skill Enhancer's min-1 floor charged a *free* skill 1 point | ✅ **fixed** — was real bug, active | yes — greyman, m-championsmush, twilight | traits (decorator, re-based) |
+| H13 | Multipower slot divisor reads `ultraSlot` off the wrapper, so it never varies | real bug (latent) | no — every corpus slot is fixed | none (not yet fixed) |
 | U1 | `capitalize` only upper-cases the first char | cosmetic (app-only) | no | (unit test) |
 | U2 | `getMultiplications(0, …)` → `-Infinity` (log of zero) | ✅ **fixed** — was real bug, active | yes — mark-li-v5a-433 (Gecko pads) | traits (decorator, re-based) |
 | U3 | `getMultiplications` off-by-one on exact powers of a non-2 step | ✅ **fixed** — was real bug (latent) | no — none; golden masters unchanged | none (no re-base needed) |
@@ -657,6 +658,38 @@ return Math.pow(step, nearest) === total ? nearest : Math.ceil(exact);
   rounds up). Existing `common.test.ts` coverage only exercises the default `step: 2`, so
   it cannot catch this. No golden-master re-base expected (no corpus divergence) — verify
   by re-running it.
+
+## H13 — A Multipower slot's divisor is always 10
+
+- **Where:** `core/traits/powers/multipowerItem.ts` —
+  `(this.characterTrait as unknown as {ultraSlot?: boolean}).ultraSlot ? 5 : 10`.
+- **Legacy:** same.
+
+**Two things are wrong with that line, and only one of them is arguable.**
+
+The unambiguous one: `ultraSlot` is a field on the **trait**, not on the `CharacterTrait` wrapper.
+`CharacterTrait` carries `trait`, `listKey`, `getCharacter` and `parentTrait` — no `ultraSlot`, and
+the cast is what stops the compiler saying so. The read is therefore always `undefined`, the
+condition always false, and **every Multipower slot divides by 10** regardless of what kind of slot
+it is. Verified by pricing the same authored slot with `ultraSlot` true and false: 6 either way.
+
+The arguable one: even reachable, `ultraSlot ? 5 : 10` looks inverted. `ULTRA_SLOT="Yes"` marks a
+**fixed** slot, which is the cheaper kind — flexibility is what you pay for — so a fixed slot should
+divide by 10 and a variable one by 5. That is the reading the accidental behaviour happens to
+implement for fixed slots. **Confirm against 6E1 before changing it**, in the spirit of the open
+`PLUSONEPIP` question in CLAUDE.md: the correction is probably `trait.ultraSlot ? 10 : 5`, but a
+plausible-looking ratio is exactly the sort of thing worth checking rather than reasoning about.
+
+- **Corpus impact:** none. All 37 fixtures use fixed slots exclusively — greyman, indigo-bunting and
+  psi-blade6 are the Multipowers, and every slot in them is `ULTRA_SLOT="Yes"` — so the accidental
+  always-10 is right for all of them. A golden master cannot see this.
+- **Consequence for authoring:** `core/authoring` emits **fixed slots only** and says so, rather
+  than offering a variable slot that would silently price as a fixed one. Widening that is gated on
+  this entry.
+- **Fix + verify:** read `ultraSlot` off the trait; settle the ratio from the rulebook; a
+  purpose-built test with both slot kinds (the corpus cannot supply one). No golden-master re-base
+  is expected, since no fixture has a variable slot — which is also why this needs its own test
+  rather than a fixture.
 
 ## U1 — `capitalize` only upper-cases the first character
 

--- a/docs/RELEASE_NOTES_2.8.0.md
+++ b/docs/RELEASE_NOTES_2.8.0.md
@@ -11,7 +11,11 @@ there, and this build doesn't repeat them.
 
 The thing to make sure testers read: **frameworks look different now**. That is
 H2, it is a fix, it applies to characters they already have, and it is the only
-change here that touches something they were already looking at.
+change here that touches their character *data*.
+
+Quick Pick (PR #48) shipped after 2.7.1 and has never been in a tester build, so
+it belongs in these notes even though it isn't part of the authoring work. It
+changes the shape of Home and the character sheet but touches no data.
 -->
 
 # 2.8.0 — release notes (draft)
@@ -19,15 +23,15 @@ change here that touches something they were already looking at.
 ## Short version (Play Console, ~500 char limit)
 
 ```
-Build a character in the app. Characteristics, skills, perks, talents, powers with
-advantages and limitations, Multipowers, martial arts, equipment, complications —
-priced live by the same engine that reads a HERO Designer file.
+Build a character in the app: characteristics, skills, powers with advantages and
+limitations, Multipowers, martial arts, complications — priced by the same engine
+that reads HERO Designer files. Set your campaign's allowance; anything past it
+counts as experience.
 
-Pick your campaign's point allowance, or type your own. Anything you spend past it
-is tracked as experience.
+Quick Pick: a 3x3 grid of your characters on Home and behind a handle on the
+sheet. Long-press a slot to pin someone.
 
-Also fixed: Multipowers, Elemental Controls and VPPs now show their slots INSIDE
-the framework instead of loose beside it. Costs don't change.
+Fixed: framework slots now sit INSIDE the framework. No cost changes.
 ```
 
 ## For testers
@@ -38,6 +42,9 @@ regression and we want to hear about it.
 
 **But one thing about your existing characters does look different** — see Fixed,
 below. It's a layout fix, not a cost change, and it's the first thing to check.
+
+**Two screens you already use have changed shape**: Home now leads with the Quick Pick
+grid, and the character sheet has a handle at the bottom. Neither touches your data.
 
 ### New: build a character in the app
 
@@ -75,6 +82,41 @@ rulebook quotes them, and the labels say which:
 character costing more than their starting points has earned the difference. The meter
 says "25 experience" rather than telling you off, and the character's sheet shows
 **400 + 25 pts** on the nameplate.
+
+### New: Quick Pick — switch characters without going back to the list
+
+A **3×3 grid of nine characters**, in two places:
+
+- **On Home**, sitting there inline.
+- **On the character sheet**, behind a **handle at the bottom of the screen**. Tap the
+  handle and the same grid slides up over the sheet; tap outside it (or the handle again)
+  to put it away.
+
+Tap any character to switch to them — it makes them active and opens their sheet. From the
+sheet it *replaces* the character you were looking at rather than stacking, so flipping
+between four characters doesn't leave you pressing Back four times to get out.
+
+If you played the old app, this is the bottom-of-screen character switcher, back.
+
+**Pinning: long-press a slot.** That opens a picker; choose whoever you want parked in that
+position, and they stay there. Long-press a pinned slot again to change or clear it.
+
+Any slot you haven't pinned **fills itself** from your recently-opened characters, so the
+grid is useful before you've pinned anything at all. Pinned slots hold their position;
+suggestions flow into whatever's left. A character only ever appears once — pin someone
+who was being suggested elsewhere and the suggestion moves aside.
+
+Two things worth knowing:
+
+- **Pinning is not the same as active.** Pins are just a launcher — nine characters you
+  want one tap away. "Active" is still the single character the dice roller and the rest of
+  the app use, and tapping a slot is what changes it.
+- **Delete a pinned character and the slot doesn't break** — it empties and refills from
+  your recents like any other gap.
+
+The sheet slides open rather than dragging. That's deliberate, not unfinished: gesture
+handling has shipped broken here twice, and tap-to-open needs none of it. If you have
+**Screen animations** off in Settings, it snaps instead.
 
 ### New: edit what you built
 
@@ -116,6 +158,11 @@ one, and for the same reason: it's the app's character, not a file you own. An i
 5. **Upgrade, don't reinstall.** Schema moves 7 → 8. Your characters should all still be
    there, and any generated ones still editable.
 6. **Go over budget on purpose** and check the sheet reads "base + earned".
+7. **Live in Quick Pick for a session.** Pin the party, then run an actual fight switching
+   between them from the sheet's handle. What we want to know is whether **nine slots and
+   one page** is the right shape — if you find yourself wanting a second page, or wanting
+   fewer and bigger, say so. Also worth checking: delete a pinned character and confirm the
+   grid refills rather than breaking.
 
 ## Known gaps
 
@@ -136,4 +183,7 @@ one, and for the same reason: it's the app's character, not a file you own. An i
   backed up yet — and uninstalling loses it. Worth knowing before you spend an evening on
   one.
 - **You can't reorder** the traits in a list; they stay in the order you added them.
+- **Quick Pick is nine slots and one page.** No pagination, no drag-to-rearrange — pinning
+  is long-press-and-choose. Whether nine is the right number is one of the things we're
+  asking you about.
 - Cost Cruncher still isn't built.

--- a/docs/RELEASE_NOTES_2.8.0.md
+++ b/docs/RELEASE_NOTES_2.8.0.md
@@ -1,0 +1,139 @@
+<!--
+Copyright 2018-Present Philip J. Guinchard — Apache-2.0
+
+Draft notes for the 2.8.0 internal-testing release. Paste into Play Console →
+Internal testing → release notes (the short version), and send the long version
+to testers however you normally reach them.
+
+Assumes testers are coming from 2.7.x. If anyone is jumping straight from 2.4.1,
+point them at RELEASE_NOTES_2.5.0.md first — the cost changes are the headline
+there, and this build doesn't repeat them.
+
+The thing to make sure testers read: **frameworks look different now**. That is
+H2, it is a fix, it applies to characters they already have, and it is the only
+change here that touches something they were already looking at.
+-->
+
+# 2.8.0 — release notes (draft)
+
+## Short version (Play Console, ~500 char limit)
+
+```
+Build a character in the app. Characteristics, skills, perks, talents, powers with
+advantages and limitations, Multipowers, martial arts, equipment, complications —
+priced live by the same engine that reads a HERO Designer file.
+
+Pick your campaign's point allowance, or type your own. Anything you spend past it
+is tracked as experience.
+
+Also fixed: Multipowers, Elemental Controls and VPPs now show their slots INSIDE
+the framework instead of loose beside it. Costs don't change.
+```
+
+## For testers
+
+**No character costs change in this build.** 2.5.0 was the one that moved costs, and
+nothing here changes how a point is priced. If a **cost** moves, that's a real
+regression and we want to hear about it.
+
+**But one thing about your existing characters does look different** — see Fixed,
+below. It's a layout fix, not a cost change, and it's the first thing to check.
+
+### New: build a character in the app
+
+Characters → **New**. You get a form, and the app prices it as you type using the same
+engine that reads a HERO Designer `.hdc` — so if it says 350 points, it means the
+same 350 points HERO Designer would.
+
+What you can build:
+
+- **Characteristics** — typed as totals, the number you'd read off a sheet. In 5E the
+  figured ones (PD, ED, SPD, REC, END, STUN) do their own arithmetic; you say what you
+  want the total to be and the cost follows.
+- **Skills, perks, talents** — pick from the rulebook, choose the characteristic a skill
+  rolls against, take it at familiarity, buy levels.
+- **Powers**, with **advantages and limitations** — Area Of Effect, Focus, and the other
+  hundred-odd, with their own options and adders. Your Blast's active and real cost move
+  as you add them.
+- **Frameworks** — Multipower, Elemental Control, Variable Power Pool, with powers inside.
+- **Martial arts** and **equipment**.
+- **Complications** (or Disadvantages, in 5E).
+
+Each section is a **list**, and tapping a row opens that one thing on its own page. The
+form for a power can run long — a name, an option, levels, a defence split, adders, and
+however many advantages — so it gets a page rather than being wedged into the list.
+
+### New: your campaign's point allowance
+
+Pick a power level, or type your own numbers. The two editions are quoted the way each
+rulebook quotes them, and the labels say which:
+
+- **5E** — "Base points", which your disadvantages then add to.
+- **6E** — "Total points", with complications granting nothing.
+
+**Anything you spend past the allowance is experience.** That's what experience is: a
+character costing more than their starting points has earned the difference. The meter
+says "25 experience" rather than telling you off, and the character's sheet shows
+**400 + 25 pts** on the nameplate.
+
+### New: edit what you built
+
+An authored character stays editable — open it and hit **Edit**. Same as a generated
+one, and for the same reason: it's the app's character, not a file you own. An imported
+`.hdc` is still read-only and always will be.
+
+### Fixed
+
+- **Frameworks keep their slots.** A Multipower, Elemental Control or Variable Power Pool
+  used to render as an **empty container with its powers sitting loose beside it**. They
+  now nest inside it, indented, where they belong.
+
+  **This affects characters you already have** — 27 of our 37 test characters had it, so
+  if yours has a framework, its sheet will look different. **No cost changes**: the
+  points were always calculated correctly, it was only ever the arrangement that was
+  wrong. If a *cost* moves on a framework, that IS a regression — tell us.
+
+  The bug was inherited from the old app and had been there the whole life of the
+  rebuild. It never showed up in testing because nothing we compared against cared about
+  arrangement.
+- **An authored character shows its points and campaign type** on the nameplate, like a
+  generated or imported one does.
+
+## What to hammer on
+
+1. **Open a character with a Multipower first.** Before anything else. Check its slots
+   are inside it, and check the costs are exactly what they were in 2.7.1. That's the one
+   change that touches what you already had.
+2. **Build a character you'd actually play**, then build the same character in HERO
+   Designer and compare the totals. Ours should match. Where it doesn't, that's the most
+   valuable bug you can file — and please say which power, because the interesting ones
+   will be about advantages and limitations.
+3. **Try to make it lie.** Take a power with an advantage and a limitation, put it in a
+   Multipower, and check the slot's cost. Take a Resistant Protection and check it
+   actually raises your PD/ED. Take a skill at familiarity and check it's 1 point and 8-.
+4. **Save, leave, come back, edit.** An authored character should re-open exactly as you
+   left it and rebuild identically. If anything drifts, we want to know.
+5. **Upgrade, don't reinstall.** Schema moves 7 → 8. Your characters should all still be
+   there, and any generated ones still editable.
+6. **Go over budget on purpose** and check the sheet reads "base + earned".
+
+## Known gaps
+
+- **Some traits aren't offered yet.** Weapon Familiarity, Transport Familiarity, Autofire
+  Skills, Defense Maneuver, Rapid Attack, Two-Weapon Fighting, Cramming, Barrier,
+  Duplication, Endurance Reserve, Flash, and the "custom" entries. The **Add** field tells
+  you how many are missing from each list. They need forms of their own — offering a
+  half-working one would let you build a character that quietly costs the wrong number,
+  which is worse than not offering it.
+- **Multipower slots are fixed slots.** Variable slots aren't offered, because the engine
+  currently prices them identically to fixed ones and we'd rather not ship a choice that
+  does nothing.
+- **Equipment doesn't add to your defences.** A Resistant Protection bought as equipment
+  costs its points and shows on the sheet, but doesn't raise PD/ED — the engine has never
+  counted equipment toward totals. The app warns you when you build one. Whether it
+  *should* count is a rules question we haven't settled.
+- **There's no export.** An authored character lives on your device and can't be shared or
+  backed up yet — and uninstalling loses it. Worth knowing before you spend an evening on
+  one.
+- **You can't reorder** the traits in a list; they stay in the order you added them.
+- Cost Cruncher still isn't built.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -17,6 +17,7 @@ import {ActivityIndicator, StyleSheet} from 'react-native';
 import {Screen, Text} from 'app/components';
 import {createDeviceRepositories} from 'app/composition/deviceRepositories';
 import {AppNavigator} from 'app/navigation/AppNavigator';
+import {AuthoringProvider} from 'app/providers/AuthoringProvider';
 import {DiceProvider} from 'app/providers/DiceProvider';
 import {GenerateProvider} from 'app/providers/GenerateProvider';
 import {ImportProvider} from 'app/providers/ImportProvider';
@@ -96,9 +97,11 @@ function ThemedApp(): React.JSX.Element {
             <ToastProvider>
                 <ImportProvider filePicker={filePicker}>
                     <GenerateProvider>
-                        <DiceProvider>
-                            <AppNavigator />
-                        </DiceProvider>
+                        <AuthoringProvider>
+                            <DiceProvider>
+                                <AppNavigator />
+                            </DiceProvider>
+                        </AuthoringProvider>
                     </GenerateProvider>
                 </ImportProvider>
             </ToastProvider>

--- a/src/app/navigation/AppNavigator.tsx
+++ b/src/app/navigation/AppNavigator.tsx
@@ -17,6 +17,7 @@ import {ActivityIndicator, Alert, Pressable, StyleSheet, View} from 'react-nativ
 import {NavigationContainer, useFocusEffect} from '@react-navigation/native';
 import {createNativeStackNavigator, type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
+import type {AuthoredCharacter} from 'core/authoring';
 import type {ImportResult} from 'infra/import';
 import {Text} from 'app/components';
 import type {RollRequest} from 'app/dice/rollRequest';
@@ -24,6 +25,7 @@ import {type GenerateResult} from 'app/providers/GenerateProvider';
 import {GenerateDialog} from 'app/screens/GenerateDialog';
 import {useImportCharacter} from 'app/providers/ImportProvider';
 import {useSettings} from 'app/providers/SettingsProvider';
+import {AuthorCharacterScreen} from 'app/screens/AuthorCharacterScreen';
 import {CharacterDetailScreen} from 'app/screens/CharacterDetailScreen';
 import {CharacterListScreen} from 'app/screens/CharacterListScreen';
 import {DiceScreen} from 'app/screens/DiceScreen';
@@ -41,6 +43,8 @@ export type RootStackParamList = {
     Home: undefined;
     CharacterList: undefined;
     CharacterDetail: {id: string};
+    /** Authoring: no params for a new character; `id` + `draft` to re-open an authored one. */
+    AuthorCharacter: {id?: string; draft?: AuthoredCharacter} | undefined;
     Dice: {request?: RollRequest; mode?: RollRequest['mode']} | undefined;
     Statistics: undefined;
     Settings: undefined;
@@ -76,6 +80,11 @@ export function AppNavigator(): React.JSX.Element {
                             // eslint-disable-next-line react/no-unstable-nested-components
                             headerRight: () => (
                                 <View style={styles.headerActions}>
+                                    <Pressable accessibilityRole="button" onPress={() => navigation.navigate('AuthorCharacter')} testID="author-character">
+                                        <Text variant="label" color={theme.colors.primary}>
+                                            New
+                                        </Text>
+                                    </Pressable>
                                     <GenerateButton
                                         onGenerated={(result) => {
                                             setImportToken((token) => token + 1);
@@ -101,6 +110,7 @@ export function AppNavigator(): React.JSX.Element {
                                 onRollRequest={(request) => navigation.navigate('Dice', {request})}
                                 // Replace, not push: flipping between characters must not grow the back stack.
                                 onSwitchCharacter={(id) => navigation.replace('CharacterDetail', {id})}
+                                onEditAuthored={(id, draft) => navigation.navigate('AuthorCharacter', {id, draft})}
                             />
                         )}
                     </Stack.Screen>
@@ -119,6 +129,19 @@ export function AppNavigator(): React.JSX.Element {
                             ),
                         })}>
                         {({route}) => <DiceScreen initialRequest={route.params?.request} initialMode={route.params?.mode} />}
+                    </Stack.Screen>
+                    <Stack.Screen name="AuthorCharacter" options={({route}) => ({title: route.params?.id === undefined ? 'New Character' : 'Edit Character'})}>
+                        {({route, navigation}) => (
+                            <AuthorCharacterScreen
+                                initial={route.params?.draft}
+                                characterId={route.params?.id}
+                                onSaved={(id) => {
+                                    setImportToken((token) => token + 1);
+                                    navigation.replace('CharacterDetail', {id});
+                                }}
+                                onCancel={() => navigation.goBack()}
+                            />
+                        )}
                     </Stack.Screen>
                     <Stack.Screen name="Statistics" options={{title: 'Statistics'}}>
                         {() => <StatisticsScreen />}

--- a/src/app/navigation/AppNavigator.tsx
+++ b/src/app/navigation/AppNavigator.tsx
@@ -17,7 +17,7 @@ import {ActivityIndicator, Alert, Pressable, StyleSheet, View} from 'react-nativ
 import {NavigationContainer, useFocusEffect} from '@react-navigation/native';
 import {createNativeStackNavigator, type NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
-import type {AuthoredCharacter} from 'core/authoring';
+import type {AuthorableCategory, AuthoredCharacter} from 'core/authoring';
 import type {ImportResult} from 'infra/import';
 import {Text} from 'app/components';
 import type {RollRequest} from 'app/dice/rollRequest';
@@ -25,7 +25,9 @@ import {type GenerateResult} from 'app/providers/GenerateProvider';
 import {GenerateDialog} from 'app/screens/GenerateDialog';
 import {useImportCharacter} from 'app/providers/ImportProvider';
 import {useSettings} from 'app/providers/SettingsProvider';
+import {AuthoringDraftProvider, type TraitAddress} from 'app/providers/AuthoringDraftProvider';
 import {AuthorCharacterScreen} from 'app/screens/AuthorCharacterScreen';
+import {AuthorTraitScreen} from 'app/screens/AuthorTraitScreen';
 import {CharacterDetailScreen} from 'app/screens/CharacterDetailScreen';
 import {CharacterListScreen} from 'app/screens/CharacterListScreen';
 import {DiceScreen} from 'app/screens/DiceScreen';
@@ -45,6 +47,11 @@ export type RootStackParamList = {
     CharacterDetail: {id: string};
     /** Authoring: no params for a new character; `id` + `draft` to re-open an authored one. */
     AuthorCharacter: {id?: string; draft?: AuthoredCharacter} | undefined;
+    /**
+     * The form for one trait. Carries only its *address* — the draft itself lives in
+     * `AuthoringDraftProvider`, so nothing large or non-serialisable rides on a route.
+     */
+    AuthorTrait: {address: TraitAddress; category: AuthorableCategory};
     Dice: {request?: RollRequest; mode?: RollRequest['mode']} | undefined;
     Statistics: undefined;
     Settings: undefined;
@@ -61,95 +68,112 @@ export function AppNavigator(): React.JSX.Element {
     return (
         <SafeAreaProvider>
             <NavigationContainer>
-                <Stack.Navigator
-                    screenOptions={{
-                        headerStyle: {backgroundColor: theme.colors.surface},
-                        headerTintColor: theme.colors.text,
-                        contentStyle: {backgroundColor: theme.colors.background},
-                        // Respect the reduce-motion preference: no push/pop transition when off.
-                        animation: settings.showAnimations ? 'default' : 'none',
-                    }}>
-                    <Stack.Screen name="Home" options={{title: 'HERO System Mobile'}}>
-                        {({navigation}) => <HomeRoute navigation={navigation} />}
-                    </Stack.Screen>
-                    <Stack.Screen
-                        name="CharacterList"
-                        options={({navigation}) => ({
-                            title: 'Characters',
-                            // headerRight is a react-navigation render prop, not a nested component definition.
-                            // eslint-disable-next-line react/no-unstable-nested-components
-                            headerRight: () => (
-                                <View style={styles.headerActions}>
-                                    <Pressable accessibilityRole="button" onPress={() => navigation.navigate('AuthorCharacter')} testID="author-character">
+                {/* Above the navigator, because the authoring screens are siblings in the stack
+                    and both edit the same draft. */}
+                <AuthoringDraftProvider>
+                    <Stack.Navigator
+                        screenOptions={{
+                            headerStyle: {backgroundColor: theme.colors.surface},
+                            headerTintColor: theme.colors.text,
+                            contentStyle: {backgroundColor: theme.colors.background},
+                            // Respect the reduce-motion preference: no push/pop transition when off.
+                            animation: settings.showAnimations ? 'default' : 'none',
+                        }}>
+                        <Stack.Screen name="Home" options={{title: 'HERO System Mobile'}}>
+                            {({navigation}) => <HomeRoute navigation={navigation} />}
+                        </Stack.Screen>
+                        <Stack.Screen
+                            name="CharacterList"
+                            options={({navigation}) => ({
+                                title: 'Characters',
+                                // headerRight is a react-navigation render prop, not a nested component definition.
+                                // eslint-disable-next-line react/no-unstable-nested-components
+                                headerRight: () => (
+                                    <View style={styles.headerActions}>
+                                        <Pressable accessibilityRole="button" onPress={() => navigation.navigate('AuthorCharacter')} testID="author-character">
+                                            <Text variant="label" color={theme.colors.primary}>
+                                                New
+                                            </Text>
+                                        </Pressable>
+                                        <GenerateButton
+                                            onGenerated={(result) => {
+                                                setImportToken((token) => token + 1);
+                                                navigation.navigate('CharacterDetail', {id: result.id});
+                                            }}
+                                        />
+                                        <ImportButton
+                                            onImported={(result) => {
+                                                setImportToken((token) => token + 1);
+                                                navigation.navigate('CharacterDetail', {id: result.id});
+                                            }}
+                                        />
+                                    </View>
+                                ),
+                            })}>
+                            {({navigation}) => (
+                                <CharacterListScreen refreshToken={importToken} onSelect={(id) => navigation.navigate('CharacterDetail', {id})} />
+                            )}
+                        </Stack.Screen>
+                        <Stack.Screen name="CharacterDetail" options={{title: ''}}>
+                            {({route, navigation}) => (
+                                <CharacterDetailScreen
+                                    characterId={route.params.id}
+                                    onReady={(character) => navigation.setOptions({title: character.name})}
+                                    onRollRequest={(request) => navigation.navigate('Dice', {request})}
+                                    // Replace, not push: flipping between characters must not grow the back stack.
+                                    onSwitchCharacter={(id) => navigation.replace('CharacterDetail', {id})}
+                                    onEditAuthored={(id, draft) => navigation.navigate('AuthorCharacter', {id, draft})}
+                                />
+                            )}
+                        </Stack.Screen>
+                        <Stack.Screen
+                            name="Dice"
+                            options={({navigation}) => ({
+                                title: 'Dice Roller',
+                                // headerRight is a react-navigation render prop, not a nested component definition.
+                                // eslint-disable-next-line react/no-unstable-nested-components
+                                headerRight: () => (
+                                    <Pressable accessibilityRole="button" onPress={() => navigation.navigate('Statistics')}>
                                         <Text variant="label" color={theme.colors.primary}>
-                                            New
+                                            Stats
                                         </Text>
                                     </Pressable>
-                                    <GenerateButton
-                                        onGenerated={(result) => {
-                                            setImportToken((token) => token + 1);
-                                            navigation.navigate('CharacterDetail', {id: result.id});
-                                        }}
-                                    />
-                                    <ImportButton
-                                        onImported={(result) => {
-                                            setImportToken((token) => token + 1);
-                                            navigation.navigate('CharacterDetail', {id: result.id});
-                                        }}
-                                    />
-                                </View>
-                            ),
-                        })}>
-                        {({navigation}) => <CharacterListScreen refreshToken={importToken} onSelect={(id) => navigation.navigate('CharacterDetail', {id})} />}
-                    </Stack.Screen>
-                    <Stack.Screen name="CharacterDetail" options={{title: ''}}>
-                        {({route, navigation}) => (
-                            <CharacterDetailScreen
-                                characterId={route.params.id}
-                                onReady={(character) => navigation.setOptions({title: character.name})}
-                                onRollRequest={(request) => navigation.navigate('Dice', {request})}
-                                // Replace, not push: flipping between characters must not grow the back stack.
-                                onSwitchCharacter={(id) => navigation.replace('CharacterDetail', {id})}
-                                onEditAuthored={(id, draft) => navigation.navigate('AuthorCharacter', {id, draft})}
-                            />
-                        )}
-                    </Stack.Screen>
-                    <Stack.Screen
-                        name="Dice"
-                        options={({navigation}) => ({
-                            title: 'Dice Roller',
-                            // headerRight is a react-navigation render prop, not a nested component definition.
-                            // eslint-disable-next-line react/no-unstable-nested-components
-                            headerRight: () => (
-                                <Pressable accessibilityRole="button" onPress={() => navigation.navigate('Statistics')}>
-                                    <Text variant="label" color={theme.colors.primary}>
-                                        Stats
-                                    </Text>
-                                </Pressable>
-                            ),
-                        })}>
-                        {({route}) => <DiceScreen initialRequest={route.params?.request} initialMode={route.params?.mode} />}
-                    </Stack.Screen>
-                    <Stack.Screen name="AuthorCharacter" options={({route}) => ({title: route.params?.id === undefined ? 'New Character' : 'Edit Character'})}>
-                        {({route, navigation}) => (
-                            <AuthorCharacterScreen
-                                initial={route.params?.draft}
-                                characterId={route.params?.id}
-                                onSaved={(id) => {
-                                    setImportToken((token) => token + 1);
-                                    navigation.replace('CharacterDetail', {id});
-                                }}
-                                onCancel={() => navigation.goBack()}
-                            />
-                        )}
-                    </Stack.Screen>
-                    <Stack.Screen name="Statistics" options={{title: 'Statistics'}}>
-                        {() => <StatisticsScreen />}
-                    </Stack.Screen>
-                    <Stack.Screen name="Settings" options={{title: 'Settings'}}>
-                        {() => <SettingsScreen />}
-                    </Stack.Screen>
-                </Stack.Navigator>
+                                ),
+                            })}>
+                            {({route}) => <DiceScreen initialRequest={route.params?.request} initialMode={route.params?.mode} />}
+                        </Stack.Screen>
+                        <Stack.Screen
+                            name="AuthorCharacter"
+                            options={({route}) => ({title: route.params?.id === undefined ? 'New Character' : 'Edit Character'})}>
+                            {({route, navigation}) => (
+                                <AuthorCharacterScreen
+                                    initial={route.params?.draft}
+                                    characterId={route.params?.id}
+                                    onSaved={(id) => {
+                                        setImportToken((token) => token + 1);
+                                        navigation.replace('CharacterDetail', {id});
+                                    }}
+                                    onCancel={() => navigation.goBack()}
+                                    onEditTrait={(address, category) => navigation.navigate('AuthorTrait', {address, category})}
+                                    onEditFramework={(index) =>
+                                        navigation.navigate('AuthorTrait', {address: {kind: 'pool', framework: index}, category: 'powers'})
+                                    }
+                                />
+                            )}
+                        </Stack.Screen>
+                        <Stack.Screen name="AuthorTrait" options={{title: 'Edit'}}>
+                            {({route, navigation}) => (
+                                <AuthorTraitScreen address={route.params.address} category={route.params.category} onDone={() => navigation.goBack()} />
+                            )}
+                        </Stack.Screen>
+                        <Stack.Screen name="Statistics" options={{title: 'Statistics'}}>
+                            {() => <StatisticsScreen />}
+                        </Stack.Screen>
+                        <Stack.Screen name="Settings" options={{title: 'Settings'}}>
+                            {() => <SettingsScreen />}
+                        </Stack.Screen>
+                    </Stack.Navigator>
+                </AuthoringDraftProvider>
             </NavigationContainer>
         </SafeAreaProvider>
     );

--- a/src/app/providers/AuthoringDraftProvider.tsx
+++ b/src/app/providers/AuthoringDraftProvider.tsx
@@ -1,0 +1,169 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The draft being authored, shared by the screens that edit it.
+ *
+ * Editing one trait happens on its own screen, so the draft cannot live in either screen's
+ * `useState` — the trait editor would have to hand its result back through navigation, and route
+ * params are meant to be serialisable identifiers rather than a whole character.
+ *
+ * So the draft lives here and the screens address parts of it by **category and index**. Context
+ * plus `useState`, which is how this app holds state everywhere (see the Phase 3 note in
+ * CLAUDE.md — there is deliberately no redux).
+ */
+import React, {createContext, useCallback, useContext, useMemo, useRef, useState} from 'react';
+import {emptyDraft, type AuthoredCharacter, type AuthoredFramework, type AuthoredPower, type AuthoredTrait} from 'core/authoring';
+
+/** Where a trait lives on a draft. `frameworks` is addressed separately — its traits nest. */
+export type DraftKey = 'skills' | 'perks' | 'talents' | 'powers' | 'martialArts' | 'equipment' | 'complications';
+
+/**
+ * Which trait an editor is editing.
+ *
+ * A framework slot needs two indices — which framework, then which slot — so it gets its own
+ * shape rather than being squeezed into the flat one. Both are plain data, so a route can carry
+ * one without anybody having to think about serialisability.
+ */
+export type TraitAddress =
+    | {readonly kind: 'trait'; readonly key: DraftKey; readonly index: number}
+    | {readonly kind: 'slot'; readonly framework: number; readonly index: number}
+    /** A framework's pool. Not a trait — it has no catalogue entry — but it does carry modifiers. */
+    | {readonly kind: 'pool'; readonly framework: number};
+
+interface DraftApi {
+    readonly draft: AuthoredCharacter;
+    readonly setDraft: (draft: AuthoredCharacter) => void;
+    /**
+     * Start a fresh authoring session from `initial`.
+     *
+     * The provider outlives any one screen — that is the point of it — so something has to say
+     * when a *new* character is being authored rather than the same one being navigated around.
+     * `sessionKey` is that: reset happens when the key changes, so returning from the trait form
+     * does not wipe the draft.
+     */
+    readonly beginSession: (sessionKey: string, initial?: AuthoredCharacter) => void;
+    /** Read the trait at an address, or null when the address no longer points at one. */
+    readonly traitAt: (address: TraitAddress) => AuthoredTrait | null;
+    /** Read a framework by index, or null when it has gone. */
+    readonly frameworkAt: (index: number) => AuthoredFramework | null;
+    /** Replace a framework by index. */
+    readonly replaceFramework: (index: number, framework: AuthoredFramework) => void;
+    /** Replace the trait at an address. A no-op if the address has gone stale. */
+    readonly replaceAt: (address: TraitAddress, trait: AuthoredTrait) => void;
+    /** Remove the trait at an address. */
+    readonly removeAt: (address: TraitAddress) => void;
+}
+
+const DraftContext = createContext<DraftApi | null>(null);
+
+export interface AuthoringDraftProviderProps {
+    /** What to start from — a stored draft when re-opening, an empty one when creating. */
+    initial?: AuthoredCharacter;
+    children: React.ReactNode;
+}
+
+export function AuthoringDraftProvider({initial, children}: AuthoringDraftProviderProps): React.JSX.Element {
+    const [draft, setDraft] = useState<AuthoredCharacter>(initial ?? emptyDraft('6E'));
+    const session = useRef<string | null>(null);
+
+    const beginSession = useCallback((sessionKey: string, seed?: AuthoredCharacter): void => {
+        if (session.current === sessionKey) {
+            return;
+        }
+
+        session.current = sessionKey;
+        setDraft(seed ?? emptyDraft('6E'));
+    }, []);
+
+    const traitAt = useCallback(
+        (address: TraitAddress): AuthoredTrait | null => {
+            if (address.kind === 'pool') {
+                return null; // a pool is not a trait; see `frameworkAt`
+            }
+
+            return address.kind === 'trait' ? draft[address.key][address.index] ?? null : draft.frameworks[address.framework]?.slots[address.index] ?? null;
+        },
+        [draft],
+    );
+
+    const frameworkAt = useCallback((index: number): AuthoredFramework | null => draft.frameworks[index] ?? null, [draft]);
+
+    const replaceFramework = useCallback(
+        (index: number, framework: AuthoredFramework): void =>
+            setDraft({...draft, frameworks: draft.frameworks.map((entry, position) => (position === index ? framework : entry))}),
+        [draft],
+    );
+
+    const replaceAt = useCallback(
+        (address: TraitAddress, trait: AuthoredTrait): void => {
+            if (address.kind === 'pool') {
+                return;
+            }
+
+            if (address.kind === 'trait') {
+                setDraft({...draft, [address.key]: draft[address.key].map((entry, index) => (index === address.index ? trait : entry))});
+                return;
+            }
+
+            setDraft({
+                ...draft,
+                frameworks: draft.frameworks.map((framework, index) =>
+                    index === address.framework
+                        ? {...framework, slots: framework.slots.map((slot, order) => (order === address.index ? (trait as AuthoredPower) : slot))}
+                        : framework,
+                ),
+            });
+        },
+        [draft],
+    );
+
+    const removeAt = useCallback(
+        (address: TraitAddress): void => {
+            if (address.kind === 'pool') {
+                return;
+            }
+
+            if (address.kind === 'trait') {
+                setDraft({...draft, [address.key]: draft[address.key].filter((_, index) => index !== address.index)});
+                return;
+            }
+
+            setDraft({
+                ...draft,
+                frameworks: draft.frameworks.map((framework: AuthoredFramework, index) =>
+                    index === address.framework ? {...framework, slots: framework.slots.filter((_, order) => order !== address.index)} : framework,
+                ),
+            });
+        },
+        [draft],
+    );
+
+    const api = useMemo<DraftApi>(
+        () => ({draft, setDraft, beginSession, traitAt, frameworkAt, replaceFramework, replaceAt, removeAt}),
+        [draft, beginSession, traitAt, frameworkAt, replaceFramework, replaceAt, removeAt],
+    );
+
+    return <DraftContext.Provider value={api}>{children}</DraftContext.Provider>;
+}
+
+export function useAuthoringDraft(): DraftApi {
+    const value = useContext(DraftContext);
+
+    if (value === null) {
+        throw new Error('useAuthoringDraft must be used within an AuthoringDraftProvider');
+    }
+
+    return value;
+}

--- a/src/app/providers/AuthoringProvider.tsx
+++ b/src/app/providers/AuthoringProvider.tsx
@@ -23,7 +23,7 @@
  * character. Nothing is mutated in place, so no edit can leave a character half-changed.
  */
 import React, {createContext, useCallback, useContext, useMemo} from 'react';
-import {build, declaredFor, toSource, type AuthoredCharacter} from 'core/authoring';
+import {build, declaredFor, remaining, spendOf, toSource, type AuthoredCharacter} from 'core/authoring';
 import {heroDesignerCharacter} from 'core/hero';
 import type {CharacterDocument} from 'core/ports';
 import {useRepositories} from 'app/providers/RepositoriesProvider';
@@ -57,11 +57,15 @@ export function AuthoringProvider({children}: {children: React.ReactNode}): Reac
 
     const save = useCallback<SaveAuthored>(
         async (draft, existingId) => {
-            const document = build(draft) as unknown as CharacterDocument;
+            const built = build(draft);
+            const document = built as unknown as CharacterDocument;
             // What the character declares it was built on. `getCharacter` builds no such block, so
             // without this the sheet's nameplate shows neither points nor campaign tier — which is
             // what an authored character did before the allowance was pickable.
-            document.basicConfiguration = declaredFor(draft.budget);
+            //
+            // Anything past the allowance is declared as experience, which is what it is: a
+            // character costing more than their starting points has earned the difference.
+            document.basicConfiguration = declaredFor(draft.budget, remaining(spendOf(built), draft.budget, draft.edition).experience);
             const name = draft.name.trim() === '' ? 'Unnamed' : draft.name.trim();
 
             // An edit keeps its id; a new character takes one derived from its name, suffixed

--- a/src/app/providers/AuthoringProvider.tsx
+++ b/src/app/providers/AuthoringProvider.tsx
@@ -23,7 +23,7 @@
  * character. Nothing is mutated in place, so no edit can leave a character half-changed.
  */
 import React, {createContext, useCallback, useContext, useMemo} from 'react';
-import {build, toSource, type AuthoredCharacter} from 'core/authoring';
+import {build, declaredFor, toSource, type AuthoredCharacter} from 'core/authoring';
 import {heroDesignerCharacter} from 'core/hero';
 import type {CharacterDocument} from 'core/ports';
 import {useRepositories} from 'app/providers/RepositoriesProvider';
@@ -58,6 +58,10 @@ export function AuthoringProvider({children}: {children: React.ReactNode}): Reac
     const save = useCallback<SaveAuthored>(
         async (draft, existingId) => {
             const document = build(draft) as unknown as CharacterDocument;
+            // What the character declares it was built on. `getCharacter` builds no such block, so
+            // without this the sheet's nameplate shows neither points nor campaign tier — which is
+            // what an authored character did before the allowance was pickable.
+            document.basicConfiguration = declaredFor(draft.budget);
             const name = draft.name.trim() === '' ? 'Unnamed' : draft.name.trim();
 
             // An edit keeps its id; a new character takes one derived from its name, suffixed

--- a/src/app/providers/AuthoringProvider.tsx
+++ b/src/app/providers/AuthoringProvider.tsx
@@ -1,0 +1,119 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Saving an authored character (docs/CHARACTER_AUTHORING.md).
+ *
+ * The same shape as `GenerateProvider`, deliberately: build the engine's input, price it through
+ * `getCharacter`, store the document alongside the thing it was built from. The only difference is
+ * which "thing" that is — a generated character keeps its recipe, an authored one keeps its draft.
+ *
+ * There is one save path for both creating and editing, because a draft fully determines a
+ * character. Nothing is mutated in place, so no edit can leave a character half-changed.
+ */
+import React, {createContext, useCallback, useContext, useMemo} from 'react';
+import {build, toSource, type AuthoredCharacter} from 'core/authoring';
+import {heroDesignerCharacter} from 'core/hero';
+import type {CharacterDocument} from 'core/ports';
+import {useRepositories} from 'app/providers/RepositoriesProvider';
+
+/** What a save reports back, so the caller can navigate to what it just wrote. */
+export interface AuthoredResult {
+    readonly id: string;
+    readonly name: string;
+}
+
+export type SaveAuthored = (draft: AuthoredCharacter, existingId?: string) => Promise<AuthoredResult>;
+
+interface AuthoringApi {
+    readonly save: SaveAuthored;
+}
+
+const AuthoringContext = createContext<AuthoringApi | null>(null);
+
+/** A name a player typed, as an id fragment. Empty names are possible, so there is a fallback. */
+const slugOf = (name: string): string => {
+    const slug = name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    return slug === '' ? 'character' : slug;
+};
+
+export function AuthoringProvider({children}: {children: React.ReactNode}): React.JSX.Element {
+    const repositories = useRepositories();
+
+    const save = useCallback<SaveAuthored>(
+        async (draft, existingId) => {
+            const document = build(draft) as unknown as CharacterDocument;
+            const name = draft.name.trim() === '' ? 'Unnamed' : draft.name.trim();
+
+            // An edit keeps its id; a new character takes one derived from its name, suffixed
+            // until it is free. An authored character has no filename to key on the way an import
+            // does, and reusing a name would silently overwrite somebody's other character.
+            const id = existingId ?? (await nextFreeId(repositories, slugOf(name)));
+
+            await repositories.characters.save({
+                id,
+                name,
+                player: draft.player.trim() === '' ? null : draft.player.trim(),
+                edition: heroDesignerCharacter.isFifth(document as never) ? '5E' : '6E',
+                filename: id,
+                document,
+                // Stated, not inferred: this is the row the player is allowed to edit, and the
+                // source is the only record of what it was built from.
+                origin: 'authored',
+                source: toSource(draft),
+            });
+
+            return {id, name};
+        },
+        [repositories],
+    );
+
+    const api = useMemo<AuthoringApi>(() => ({save}), [save]);
+
+    return <AuthoringContext.Provider value={api}>{children}</AuthoringContext.Provider>;
+}
+
+/** `authored-<slug>`, then `-2`, `-3`… until nothing is using it. */
+async function nextFreeId(repositories: ReturnType<typeof useRepositories>, slug: string): Promise<string> {
+    const taken = new Set((await repositories.characters.list()).map((summary) => summary.id));
+    const base = `authored-${slug}`;
+
+    if (!taken.has(base)) {
+        return base;
+    }
+
+    let suffix = 2;
+    while (taken.has(`${base}-${suffix}`)) {
+        suffix += 1;
+    }
+
+    return `${base}-${suffix}`;
+}
+
+function useAuthoringApi(): AuthoringApi {
+    const value = useContext(AuthoringContext);
+
+    if (value === null) {
+        throw new Error('useSaveAuthored must be used within an AuthoringProvider');
+    }
+
+    return value;
+}
+
+/** Save a draft — new when no id is given, an edit in place when one is. */
+export const useSaveAuthored = (): SaveAuthored => useAuthoringApi().save;

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -31,7 +31,8 @@ import {
     authorable,
     build,
     characteristics as catalogueCharacteristics,
-    DEFAULT_BUDGET,
+    allowanceFor,
+    allowancesFor,
     emptyDraft,
     frameworkSummaries,
     isSaveable,
@@ -104,8 +105,7 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel, 
 
     const edit = useCallback((address: TraitAddress, category: AuthorableCategory) => onEditTrait?.(address, category), [onEditTrait]);
 
-    const budget = DEFAULT_BUDGET[draft.edition];
-    const left = spend === null ? null : remaining(spend, budget, draft.edition);
+    const left = spend === null ? null : remaining(spend, draft.budget, draft.edition);
 
     const commit = useCallback(() => {
         // Guarded here as well as on the button. Disabling a control is a UI affordance; refusing
@@ -146,7 +146,9 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel, 
                     </View>
                 </Card>
 
-                <SpendMeter left={left} complications={spend?.complications ?? 0} limit={budget.complicationLimit} edition={draft.edition} />
+                <SpendMeter left={left} complications={spend?.complications ?? 0} limit={draft.budget.complicationLimit} edition={draft.edition} />
+
+                <Allowance draft={draft} onChange={setDraft} />
 
                 <Characteristics draft={draft} onChange={setDraft} />
 
@@ -216,6 +218,71 @@ function EditionPicker({
                 onChange={(edition) => onChange({...emptyDraft(edition as AuthoringEdition), name: draft.name, player: draft.player})}
             />
         </View>
+    );
+}
+
+const CUSTOM = 'Custom';
+
+/**
+ * What the campaign allows.
+ *
+ * Named levels for the common cases, and both numbers editable for a campaign the rulebooks have
+ * no name for. Editing either number puts the picker on "Custom" by itself — the label is derived
+ * from the numbers rather than stored, so it can never claim a level the numbers do not match.
+ *
+ * The two editions are quoted in different units and the labels say so, because "400" means the
+ * whole allowance in 6E and a pre-disadvantage base in 5E. Getting that backwards is the single
+ * easiest mistake here — see `POINT_ALLOWANCES`.
+ */
+function Allowance({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
+    const offered = useMemo(() => allowancesFor(draft.edition), [draft.edition]);
+    const named = allowanceFor(draft.budget, draft.edition);
+
+    const set = (patch: Partial<AuthoredCharacter['budget']>): void => onChange({...draft, budget: {...draft.budget, ...patch}});
+
+    return (
+        <Card>
+            <View style={styles.fields}>
+                <Text variant="label" muted>
+                    CAMPAIGN
+                </Text>
+
+                <SelectField
+                    label="Power level"
+                    value={named?.name ?? CUSTOM}
+                    options={[...offered.map((allowance) => allowance.name), CUSTOM]}
+                    onChange={(name) => {
+                        const allowance = offered.find((candidate) => candidate.name === name);
+
+                        // "Custom" selects nothing — it is what the numbers already say. Picking it
+                        // and having the budget jump would be the opposite of what it means.
+                        if (allowance !== undefined) {
+                            set({base: allowance.base, complicationLimit: allowance.complicationLimit});
+                        }
+                    }}
+                    testID="author-power-level"
+                />
+
+                <View style={styles.grid}>
+                    <View style={styles.budgetCell}>
+                        <NumberField
+                            label={draft.edition === '5E' ? 'Base points' : 'Total points'}
+                            value={String(draft.budget.base)}
+                            onChangeText={(text) => set({base: Math.max(0, Number.parseInt(text, 10) || 0)})}
+                            testID="author-budget-base"
+                        />
+                    </View>
+                    <View style={styles.budgetCell}>
+                        <NumberField
+                            label={draft.edition === '5E' ? 'Disadvantage limit' : 'Complication limit'}
+                            value={String(draft.budget.complicationLimit)}
+                            onChangeText={(text) => set({complicationLimit: Math.max(0, Number.parseInt(text, 10) || 0)})}
+                            testID="author-budget-limit"
+                        />
+                    </View>
+                </View>
+            </View>
+        </Card>
     );
 }
 
@@ -636,6 +703,9 @@ const styles = StyleSheet.create({
     },
     gridCell: {
         width: '30%',
+    },
+    budgetCell: {
+        width: '46%',
     },
     complication: {
         rowGap: 8,

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -277,13 +277,17 @@ function Characteristics({draft, onChange}: {draft: AuthoredCharacter; onChange:
 }
 
 /** How each authorable category is titled and stored on the draft. */
-type DraftKey = 'skills' | 'perks' | 'talents' | 'powers' | 'complications';
+type DraftKey = 'skills' | 'perks' | 'talents' | 'powers' | 'martialArts' | 'equipment' | 'complications';
 
 const SECTIONS: Array<{category: AuthorableCategory; key: DraftKey; title: (edition: AuthoringEdition) => string}> = [
     {category: 'skills', key: 'skills', title: () => 'SKILLS'},
     {category: 'perks', key: 'perks', title: () => 'PERKS'},
     {category: 'talents', key: 'talents', title: () => 'TALENTS'},
     {category: 'powers', key: 'powers', title: () => 'POWERS'},
+    {category: 'martialArts', key: 'martialArts', title: () => 'MARTIAL ARTS'},
+    // Equipment draws on the powers catalogue: an item is a power in a different bucket, which is
+    // exactly how `populateTrait` reads it.
+    {category: 'powers', key: 'equipment', title: () => 'EQUIPMENT'},
     // The rules rename them between editions, and so does the sheet.
     {category: 'disadvantages', key: 'complications', title: (edition) => (edition === '5E' ? 'DISADVANTAGES' : 'COMPLICATIONS')},
 ];

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -42,12 +42,14 @@ import {
     withheld,
     type AuthorableCategory,
     type AuthoredCharacter,
+    type AuthoredFramework,
     type AuthoredModifier,
     type AuthoredPower,
     type AuthoredTrait,
     type AuthoringEdition,
     type CatalogueTrait,
     type FieldGroup,
+    type FrameworkKind,
     type Problem,
 } from 'core/authoring';
 import {Button, Card, NumberField, Screen, SegmentedControl, SelectField, Text, TextField} from 'app/components';
@@ -122,6 +124,8 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
                 <SpendMeter left={left} complications={spend?.complications ?? 0} limit={budget.complicationLimit} edition={draft.edition} />
 
                 <Characteristics draft={draft} onChange={setDraft} />
+
+                <Frameworks draft={draft} onChange={setDraft} />
 
                 {SECTIONS.map((section) => (
                     <TraitSection
@@ -667,6 +671,124 @@ function Modifiers({
 
             <SelectField label="Add advantage or limitation" value="" options={available.map((entry) => entry.display)} onChange={add} testID={`author-add-modifier-${id}`} />
         </View>
+    );
+}
+
+const FRAMEWORK_KINDS: Array<{value: FrameworkKind; label: string}> = [
+    {value: 'multipower', label: 'Multipower'},
+    {value: 'elementalControl', label: 'Elemental Control'},
+    {value: 'vpp', label: 'Variable Power Pool'},
+];
+
+/**
+ * Power frameworks: a pool, and the powers drawing on it.
+ *
+ * Its own section rather than a kind of power, because a framework is not priced like one — the
+ * container costs its reserve and each slot a fraction of what it would cost alone. Slots reuse
+ * {@link TraitRow}, so a power in a pool is edited exactly like a power outside one.
+ */
+function Frameworks({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
+    const powers = useMemo(() => authorable('powers', draft.edition), [draft.edition]);
+    const byXmlid = useMemo(() => new Map(catalogue('powers', draft.edition).map((entry) => [entry.xmlid, entry])), [draft.edition]);
+
+    const update = (index: number, revised: AuthoredFramework): void =>
+        onChange({...draft, frameworks: draft.frameworks.map((entry, position) => (position === index ? revised : entry))});
+
+    const add = (label: string): void => {
+        const kind = FRAMEWORK_KINDS.find((candidate) => candidate.label === label);
+
+        if (kind !== undefined) {
+            onChange({...draft, frameworks: [...draft.frameworks, {kind: kind.value, name: '', reserve: 0, modifiers: [], slots: []}]});
+        }
+    };
+
+    return (
+        <Card>
+            <Text variant="label" muted>
+                FRAMEWORKS
+            </Text>
+
+            <View style={styles.fields}>
+                {draft.frameworks.map((framework, index) => (
+                    <View key={`${framework.kind}-${index}`} style={styles.complication}>
+                        <View style={styles.complicationHead}>
+                            <Text variant="label">{FRAMEWORK_KINDS.find((kind) => kind.value === framework.kind)?.label ?? framework.kind}</Text>
+                            <Button
+                                label="Remove"
+                                onPress={() => onChange({...draft, frameworks: draft.frameworks.filter((_, position) => position !== index)})}
+                                variant="secondary"
+                                testID={`author-remove-framework-${index}`}
+                            />
+                        </View>
+
+                        <TextField label="Name" value={framework.name} onChangeText={(name) => update(index, {...framework, name})} maxLength={60} testID={`author-framework-name-${index}`} />
+
+                        <NumberField
+                            label={framework.kind === 'vpp' ? 'Pool' : 'Reserve'}
+                            value={String(framework.reserve)}
+                            onChangeText={(text) => update(index, {...framework, reserve: Math.max(0, Number.parseInt(text, 10) || 0)})}
+                            testID={`author-framework-reserve-${index}`}
+                        />
+
+                        <Modifiers
+                            id={`framework-${index}`}
+                            edition={draft.edition}
+                            power={{xmlid: 'GENERIC_OBJECT', input: '', adders: [], modifiers: framework.modifiers} as AuthoredPower}
+                            onChange={(revised) => update(index, {...framework, modifiers: (revised as AuthoredPower).modifiers})}
+                        />
+
+                        {framework.slots.map((slot, order) => {
+                            const entry = byXmlid.get(slot.xmlid);
+
+                            return entry === undefined ? null : (
+                                <TraitRow
+                                    key={`${slot.xmlid}-${order}`}
+                                    index={order}
+                                    draftKey={`framework-${index}-slot`}
+                                    edition={draft.edition}
+                                    entry={entry}
+                                    trait={slot}
+                                    onChange={(revised) => update(index, {...framework, slots: framework.slots.map((entry2, p) => (p === order ? (revised as AuthoredPower) : entry2))})}
+                                    onRemove={() => update(index, {...framework, slots: framework.slots.filter((_, p) => p !== order)})}
+                                />
+                            );
+                        })}
+
+                        <SelectField
+                            label="Add a power to this framework"
+                            value=""
+                            options={powers.map((entry) => entry.display)}
+                            onChange={(display) => {
+                                const entry = powers.find((candidate) => candidate.display === display);
+
+                                if (entry !== undefined) {
+                                    update(index, {
+                                        ...framework,
+                                        slots: [
+                                            ...framework.slots,
+                                            {xmlid: entry.xmlid, input: '', adders: [], levels: 0, modifiers: [], ...(entry.fieldGroup === null ? {} : {defense: {pd: 0, ed: 0, mental: 0, power: 0}})},
+                                        ],
+                                    });
+                                }
+                            }}
+                            testID={`author-add-slot-${index}`}
+                        />
+                    </View>
+                ))}
+
+                <SelectField
+                    label="Add"
+                    value=""
+                    options={FRAMEWORK_KINDS.map((kind) => kind.label)}
+                    onChange={add}
+                    // Fixed slots only — the variable kind's divisor is unreachable in the engine
+                    // (H13 in docs/KNOWN_DEVIATIONS.md), so offering it would price a variable slot
+                    // as a fixed one and say nothing about it.
+                    hint="Slots are fixed slots"
+                    testID="author-add-framework"
+                />
+            </View>
+        </Card>
     );
 }
 

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -26,35 +26,34 @@
  * (skills, powers) mostly a matter of pointing the same components at more catalogue.
  */
 import React, {useCallback, useMemo, useState} from 'react';
-import {Alert, ScrollView, StyleSheet, View} from 'react-native';
+import {Alert, Pressable, ScrollView, StyleSheet, View} from 'react-native';
 import {
     authorable,
     build,
-    catalogue,
     characteristics as catalogueCharacteristics,
     DEFAULT_BUDGET,
     emptyDraft,
+    frameworkSummaries,
     isSaveable,
     remaining,
     spendOf,
+    summaries,
     validate,
-    modifiers,
     withheld,
     type AuthorableCategory,
     type AuthoredCharacter,
     type AuthoredFramework,
-    type AuthoredModifier,
-    type AuthoredPower,
-    type AuthoredTrait,
     type AuthoringEdition,
-    type CatalogueTrait,
-    type FieldGroup,
     type FrameworkKind,
     type Problem,
 } from 'core/authoring';
 import {Button, Card, NumberField, Screen, SegmentedControl, SelectField, Text, TextField} from 'app/components';
+import {useAuthoringDraft, type TraitAddress} from 'app/providers/AuthoringDraftProvider';
 import {useSaveAuthored} from 'app/providers/AuthoringProvider';
 import {useTheme} from 'app/theme';
+
+/** The engine's built character — a dynamic object graph, as everywhere else it is handled. */
+type Obj = Record<string, any>;
 
 export interface AuthorCharacterScreenProps {
     /** Re-open an existing authored character instead of starting fresh. */
@@ -63,6 +62,13 @@ export interface AuthorCharacterScreenProps {
     characterId?: string;
     onSaved: (id: string) => void;
     onCancel: () => void;
+    /**
+     * Open the form for one trait. Absent when there is nowhere to go — the rows then do nothing
+     * rather than the screen having to know whether it is inside a navigator.
+     */
+    onEditTrait?: (address: TraitAddress, category: AuthorableCategory) => void;
+    /** Open the advantages-and-limitations form for a framework's pool. */
+    onEditFramework?: (index: number) => void;
 }
 
 const EDITIONS: Array<{value: AuthoringEdition; label: string}> = [
@@ -70,23 +76,33 @@ const EDITIONS: Array<{value: AuthoringEdition; label: string}> = [
     {value: '5E', label: '5th Edition'},
 ];
 
-export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}: AuthorCharacterScreenProps): React.JSX.Element {
+export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel, onEditTrait, onEditFramework}: AuthorCharacterScreenProps): React.JSX.Element {
     const save = useSaveAuthored();
-    const [draft, setDraft] = useState<AuthoredCharacter>(initial ?? emptyDraft('6E'));
+    const {draft, setDraft, beginSession} = useAuthoringDraft();
     const [busy, setBusy] = useState(false);
 
-    // The engine's answer, not a tally kept beside it. Rebuilt whenever the draft changes.
-    const {spend, problems} = useMemo(() => {
+    // The draft lives above this screen so the trait form can share it, which means *this* screen
+    // has to say when a new character is being started. Keyed on the row being edited, so coming
+    // back from the trait form is not a new session and does not wipe what was typed.
+    beginSession(characterId ?? 'new', initial);
+
+    // Built once per change, and everything on the screen reads it: the meter, and the cost on
+    // every row. One build means a row and the total can never tell different stories.
+    const {character, spend, problems} = useMemo(() => {
         const validated = validate(draft);
 
         // A draft with errors may not be buildable at all — an unknown characteristic throws
-        // rather than pricing at 0 — so the meter reads zero rather than crashing the screen.
+        // rather than pricing at 0 — so the meter says so rather than crashing the screen.
         if (!isSaveable(validated)) {
-            return {spend: null, problems: validated};
+            return {character: null, spend: null, problems: validated};
         }
 
-        return {spend: spendOf(build(draft)), problems: validated};
+        const built = build(draft);
+
+        return {character: built, spend: spendOf(built), problems: validated};
     }, [draft]);
+
+    const edit = useCallback((address: TraitAddress, category: AuthorableCategory) => onEditTrait?.(address, category), [onEditTrait]);
 
     const budget = DEFAULT_BUDGET[draft.edition];
     const left = spend === null ? null : remaining(spend, budget, draft.edition);
@@ -101,7 +117,10 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
 
         setBusy(true);
         save(draft, characterId)
-            .then((result) => onSaved(result.id), (error: unknown) => Alert.alert('Could not save', error instanceof Error ? error.message : 'That character could not be saved.'))
+            .then(
+                (result) => onSaved(result.id),
+                (error: unknown) => Alert.alert('Could not save', error instanceof Error ? error.message : 'That character could not be saved.'),
+            )
             .finally(() => setBusy(false));
     }, [busy, problems, save, draft, characterId, onSaved]);
 
@@ -115,7 +134,13 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
                         </Text>
 
                         <TextField label="Name" value={draft.name} onChangeText={(name) => setDraft({...draft, name})} maxLength={60} testID="author-name" />
-                        <TextField label="Player" value={draft.player} onChangeText={(player) => setDraft({...draft, player})} maxLength={60} testID="author-player" />
+                        <TextField
+                            label="Player"
+                            value={draft.player}
+                            onChangeText={(player) => setDraft({...draft, player})}
+                            maxLength={60}
+                            testID="author-player"
+                        />
 
                         <EditionPicker draft={draft} onChange={setDraft} locked={characterId !== undefined} />
                     </View>
@@ -125,7 +150,7 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
 
                 <Characteristics draft={draft} onChange={setDraft} />
 
-                <Frameworks draft={draft} onChange={setDraft} />
+                <Frameworks draft={draft} onChange={setDraft} character={character} onEdit={edit} onEditPool={(index) => onEditFramework?.(index)} />
 
                 {SECTIONS.map((section) => (
                     <TraitSection
@@ -135,6 +160,8 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
                         title={section.title(draft.edition)}
                         draft={draft}
                         onChange={setDraft}
+                        character={character}
+                        onEdit={edit}
                     />
                 ))}
 
@@ -158,7 +185,15 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
  * stored document was priced by one rulebook and re-pricing it under the other is a new character,
  * not an edit.
  */
-function EditionPicker({draft, onChange, locked}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void; locked: boolean}): React.JSX.Element | null {
+function EditionPicker({
+    draft,
+    onChange,
+    locked,
+}: {
+    draft: AuthoredCharacter;
+    onChange: (draft: AuthoredCharacter) => void;
+    locked: boolean;
+}): React.JSX.Element | null {
     if (locked) {
         return (
             <View>
@@ -293,11 +328,14 @@ const SECTIONS: Array<{category: AuthorableCategory; key: DraftKey; title: (edit
 ];
 
 /**
- * One category's list, every field of it generated from the template.
+ * One category's list: a row per trait, and a way to add another.
  *
- * This component is the whole of Phase B's UI. Skills, perks, talents and complications differ in
- * which fields their template entries declare, not in kind, so there is one renderer and the
- * catalogue decides what it draws.
+ * The form for a trait is not here — a power's can run to a defence split, a dozen adders and any
+ * number of advantages, and rendering every one inline made this screen scroll for a very long
+ * way. Each row says what the trait is and what it costs, and opens {@link AuthorTraitScreen}.
+ *
+ * The costs come from {@link summaries}, which prices the *built* character — so a row and the
+ * meter above it can never disagree.
  */
 function TraitSection({
     category,
@@ -305,17 +343,21 @@ function TraitSection({
     title,
     draft,
     onChange,
+    character,
+    onEdit,
 }: {
     category: AuthorableCategory;
     draftKey: DraftKey;
     title: string;
     draft: AuthoredCharacter;
     onChange: (draft: AuthoredCharacter) => void;
+    character: Obj | null;
+    onEdit: (address: TraitAddress, category: AuthorableCategory) => void;
 }): React.JSX.Element {
     const offered = useMemo(() => authorable(category, draft.edition), [category, draft.edition]);
     const notYet = useMemo(() => withheld(category, draft.edition), [category, draft.edition]);
-    const byXmlid = useMemo(() => new Map(catalogue(category, draft.edition).map((entry) => [entry.xmlid, entry])), [category, draft.edition]);
     const taken = draft[draftKey];
+    const rows = character === null ? [] : summaries(character, draftKey === 'complications' ? 'disadvantages' : draftKey);
 
     const add = (display: string): void => {
         const entry = offered.find((candidate) => candidate.display === display);
@@ -326,7 +368,8 @@ function TraitSection({
 
         // Seeded with the only unambiguous answers: a lone characteristic choice, and levels at
         // zero. Anything the player must decide is left blank so `validate` asks for it rather
-        // than the form quietly picking.
+        // than the form quietly picking. Then straight into the form — adding a trait and never
+        // being shown its options is how you end up with a row that says it needs something.
         onChange({
             ...draft,
             [draftKey]: [
@@ -342,12 +385,9 @@ function TraitSection({
                 },
             ],
         });
+
+        onEdit({kind: 'trait', key: draftKey, index: taken.length}, category);
     };
-
-    const update = (index: number, revised: AuthoredTrait): void =>
-        onChange({...draft, [draftKey]: taken.map((entry, position) => (position === index ? revised : entry))});
-
-    const remove = (index: number): void => onChange({...draft, [draftKey]: taken.filter((_, position) => position !== index)});
 
     return (
         <Card>
@@ -356,26 +396,15 @@ function TraitSection({
             </Text>
 
             <View style={styles.fields}>
-                {taken.map((entry, index) => {
-                    const catalogueEntry = byXmlid.get(entry.xmlid);
-
-                    return catalogueEntry === undefined ? (
-                        <Text key={`${entry.xmlid}-${index}`} testID={`author-${draftKey}-unknown-${index}`}>
-                            {draft.edition} has no “{entry.xmlid}”.
-                        </Text>
-                    ) : (
-                        <TraitRow
-                            key={`${entry.xmlid}-${index}`}
-                            index={index}
-                            draftKey={draftKey}
-                            edition={draft.edition}
-                            entry={catalogueEntry}
-                            trait={entry}
-                            onChange={(revised) => update(index, revised)}
-                            onRemove={() => remove(index)}
-                        />
-                    );
-                })}
+                {taken.map((entry, index) => (
+                    <TraitListRow
+                        key={`${entry.xmlid}-${index}`}
+                        label={rows[index]?.label ?? entry.xmlid}
+                        cost={rows[index]?.cost ?? 0}
+                        onPress={() => onEdit({kind: 'trait', key: draftKey, index}, category)}
+                        testID={`author-row-${draftKey}-${index}`}
+                    />
+                ))}
 
                 <SelectField
                     label="Add"
@@ -392,292 +421,40 @@ function TraitSection({
     );
 }
 
+/** One line in a category list: what it is, what it costs, and a tap to open it. */
+function TraitListRow({
+    label,
+    cost,
+    onPress,
+    testID,
+    indented = false,
+}: {
+    label: string;
+    cost: number;
+    onPress: () => void;
+    testID: string;
+    indented?: boolean;
+}): React.JSX.Element {
+    const theme = useTheme();
+
+    return (
+        <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`${label}, ${cost} points`}
+            onPress={onPress}
+            testID={testID}
+            style={[styles.row, indented ? styles.rowIndented : null, {borderColor: theme.colors.border}]}>
+            <Text style={styles.rowLabel} numberOfLines={2}>
+                {label}
+            </Text>
+            <Text variant="label" muted>
+                {cost}
+            </Text>
+        </Pressable>
+    );
+}
+
 /** One trait: whichever of free text, characteristic, option, levels, familiarity and adders it declares. */
-function TraitRow({
-    index,
-    draftKey,
-    edition,
-    entry,
-    trait,
-    onChange,
-    onRemove,
-}: {
-    index: number;
-    draftKey: string;
-    edition: AuthoringEdition;
-    entry: CatalogueTrait;
-    trait: AuthoredTrait;
-    onChange: (trait: AuthoredTrait) => void;
-    onRemove: () => void;
-}): React.JSX.Element {
-    const id = `${draftKey}-${index}`;
-
-    const setAdder = (xmlid: string, patch: {option?: string; text?: string; levels?: number}): void => {
-        const existing = trait.adders.find((adder) => adder.xmlid === xmlid);
-        const adders = existing === undefined ? [...trait.adders, {xmlid, ...patch}] : trait.adders.map((adder) => (adder.xmlid === xmlid ? {...adder, ...patch} : adder));
-
-        onChange({...trait, adders});
-    };
-
-    return (
-        <View style={styles.complication}>
-            <View style={styles.complicationHead}>
-                <Text variant="label">{entry.display}</Text>
-                <Button label="Remove" onPress={onRemove} variant="secondary" testID={`author-remove-${id}`} />
-            </View>
-
-            {/* Only powers are named. A skill's label is its own name; a power's is whatever the
-                player called it — "Fire Bolt (Blast)". */}
-            {entry.modifiable ? (
-                <TextField label="Name" value={trait.name ?? ''} onChangeText={(name) => onChange({...trait, name})} maxLength={60} testID={`author-name-${id}`} />
-            ) : null}
-
-            {entry.inputLabel === null ? null : (
-                <TextField label={entry.inputLabel} value={trait.input} onChangeText={(input) => onChange({...trait, input})} maxLength={80} testID={`author-input-${id}`} />
-            )}
-
-            {entry.fieldGroup === null ? null : <DefenseFields id={id} group={entry.fieldGroup} trait={trait} onChange={onChange} />}
-
-            {entry.familiarity === null ? null : (
-                <SegmentedControl
-                    segments={[
-                        {value: 'full', label: 'Full skill'},
-                        {value: 'familiarity', label: `Familiarity (${entry.familiarity.roll}-)`},
-                    ]}
-                    value={trait.familiarity === true ? 'familiarity' : 'full'}
-                    // A familiarity is a different purchase, not the skill at zero — so switching
-                    // drops the characteristic and levels rather than keeping them around unused.
-                    onChange={(mode) =>
-                        onChange(
-                            mode === 'familiarity'
-                                ? {xmlid: trait.xmlid, input: trait.input, adders: trait.adders, familiarity: true}
-                                : {xmlid: trait.xmlid, input: trait.input, adders: trait.adders, levels: 0, ...(entry.characteristics.length === 1 ? {characteristic: entry.characteristics[0].characteristic} : {})},
-                        )
-                    }
-                />
-            )}
-
-            {entry.characteristics.length > 1 && trait.familiarity !== true ? (
-                <SelectField
-                    label="Based on"
-                    value={trait.characteristic ?? ''}
-                    options={entry.characteristics.map((choice) => choice.characteristic)}
-                    onChange={(characteristic) => onChange({...trait, characteristic})}
-                    testID={`author-characteristic-${id}`}
-                />
-            ) : null}
-
-            {entry.options.length === 0 ? null : (
-                <SelectField
-                    label={entry.display}
-                    value={entry.options.find((option) => option.xmlid === trait.option)?.display ?? ''}
-                    options={entry.options.map((option) => option.display)}
-                    onChange={(display) => onChange({...trait, option: entry.options.find((option) => option.display === display)?.xmlid})}
-                    testID={`author-option-${id}`}
-                />
-            )}
-
-            {entry.levels === null || trait.familiarity === true ? null : (
-                <NumberField
-                    label={entry.levels.label}
-                    value={trait.levels === undefined ? '' : String(trait.levels)}
-                    onChangeText={(text) => onChange({...trait, levels: text.trim() === '' ? 0 : Math.max(0, Number.parseInt(text, 10) || 0)})}
-                    testID={`author-levels-${id}`}
-                />
-            )}
-
-            {entry.adders.map((adder) => {
-                const chosen = trait.adders.find((candidate) => candidate.xmlid === adder.xmlid);
-
-                if (adder.freeText) {
-                    return (
-                        <TextField
-                            key={adder.xmlid}
-                            label={adder.display}
-                            value={chosen?.text ?? ''}
-                            onChangeText={(text) => setAdder(adder.xmlid, {text})}
-                            maxLength={80}
-                            testID={`author-adder-${id}-${adder.xmlid}`}
-                        />
-                    );
-                }
-
-                if (adder.options.length === 0) {
-                    return null; // a flat yes/no adder — needs a switch, which is its own change
-                }
-
-                return (
-                    <SelectField
-                        key={adder.xmlid}
-                        label={adder.required ? adder.display : `${adder.display} (optional)`}
-                        value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
-                        options={adder.options.map((option) => option.display)}
-                        onChange={(display) => setAdder(adder.xmlid, {option: adder.options.find((option) => option.display === display)?.xmlid})}
-                        testID={`author-adder-${id}-${adder.xmlid}`}
-                    />
-                );
-            })}
-
-            {entry.modifiable ? <Modifiers id={id} edition={edition} power={trait as AuthoredPower} onChange={onChange} /> : null}
-        </View>
-    );
-}
-
-/**
- * The defences a Resistant Protection is split across.
- *
- * Four numbers with no template behind them — see `FieldGroup`. The power's `levels` is derived
- * from their sum at emit time, so there is nothing here for the player to keep in step.
- */
-function DefenseFields({
-    id,
-    group,
-    trait,
-    onChange,
-}: {
-    id: string;
-    group: FieldGroup;
-    trait: AuthoredTrait;
-    onChange: (trait: AuthoredTrait) => void;
-}): React.JSX.Element {
-    const defense = (trait as AuthoredPower).defense ?? {pd: 0, ed: 0, mental: 0, power: 0};
-
-    return (
-        <View>
-            <Text variant="caption" muted>
-                {group.label}
-            </Text>
-            <View style={styles.grid}>
-                {group.fields.map((field) => (
-                    <View key={field.key} style={styles.gridCell}>
-                        <NumberField
-                            label={field.label}
-                            value={String(defense[field.key])}
-                            onChangeText={(text) => onChange({...trait, defense: {...defense, [field.key]: Math.max(0, Number.parseInt(text, 10) || 0)}} as AuthoredTrait)}
-                            testID={`author-defense-${id}-${field.key}`}
-                        />
-                    </View>
-                ))}
-            </View>
-        </View>
-    );
-}
-
-/**
- * A power's advantages and limitations.
- *
- * One list, not two, because which is which is the sign of what a modifier ends up costing rather
- * than a property of the modifier — `ModifierCalculator` splits them on exactly that, and an
- * option can flip a modifier from one to the other.
- */
-function Modifiers({
-    id,
-    edition,
-    power,
-    onChange,
-}: {
-    id: string;
-    edition: AuthoringEdition;
-    power: AuthoredPower;
-    onChange: (trait: AuthoredTrait) => void;
-}): React.JSX.Element {
-    const available = useMemo(() => modifiers(edition), [edition]);
-    const byXmlid = useMemo(() => new Map(available.map((entry) => [entry.xmlid, entry])), [available]);
-
-    const add = (display: string): void => {
-        const entry = available.find((candidate) => candidate.display === display);
-
-        if (entry !== undefined) {
-            onChange({...power, modifiers: [...power.modifiers, {xmlid: entry.xmlid, adders: []}]} as AuthoredTrait);
-        }
-    };
-
-    const update = (index: number, revised: AuthoredModifier): void =>
-        onChange({...power, modifiers: power.modifiers.map((entry, position) => (position === index ? revised : entry))} as AuthoredTrait);
-
-    const remove = (index: number): void => onChange({...power, modifiers: power.modifiers.filter((_, position) => position !== index)} as AuthoredTrait);
-
-    return (
-        <View style={styles.modifiers}>
-            <Text variant="caption" muted>
-                Advantages &amp; limitations
-            </Text>
-
-            {power.modifiers.map((applied, index) => {
-                const entry = byXmlid.get(applied.xmlid);
-                const modifierId = `${id}-mod-${index}`;
-
-                return entry === undefined ? (
-                    <Text key={modifierId} testID={`author-modifier-unknown-${modifierId}`}>
-                        {edition} has no “{applied.xmlid}”.
-                    </Text>
-                ) : (
-                    <View key={modifierId} style={styles.complication}>
-                        <View style={styles.complicationHead}>
-                            <Text>{entry.display}</Text>
-                            <Button label="Remove" onPress={() => remove(index)} variant="secondary" testID={`author-remove-${modifierId}`} />
-                        </View>
-
-                        {entry.freeText ? (
-                            <TextField
-                                label={entry.display}
-                                value={applied.text ?? ''}
-                                onChangeText={(text) => update(index, {...applied, text})}
-                                maxLength={80}
-                                testID={`author-modifier-text-${modifierId}`}
-                            />
-                        ) : null}
-
-                        {entry.options.length === 0 ? null : (
-                            <SelectField
-                                label="Which"
-                                value={entry.options.find((option) => option.xmlid === applied.option)?.display ?? ''}
-                                options={entry.options.map((option) => option.display)}
-                                onChange={(display) => update(index, {...applied, option: entry.options.find((option) => option.display === display)?.xmlid})}
-                                testID={`author-modifier-option-${modifierId}`}
-                            />
-                        )}
-
-                        {entry.levels === null ? null : (
-                            <NumberField
-                                label={entry.levels.label}
-                                value={applied.levels === undefined ? '' : String(applied.levels)}
-                                onChangeText={(text) => update(index, {...applied, levels: text.trim() === '' ? 0 : Math.max(0, Number.parseInt(text, 10) || 0)})}
-                                testID={`author-modifier-levels-${modifierId}`}
-                            />
-                        )}
-
-                        {entry.adders.map((adder) => {
-                            const chosen = applied.adders.find((candidate) => candidate.xmlid === adder.xmlid);
-                            const setNested = (patch: {option?: string}): void =>
-                                update(index, {
-                                    ...applied,
-                                    adders:
-                                        chosen === undefined
-                                            ? [...applied.adders, {xmlid: adder.xmlid, ...patch}]
-                                            : applied.adders.map((candidate) => (candidate.xmlid === adder.xmlid ? {...candidate, ...patch} : candidate)),
-                                });
-
-                            return adder.options.length === 0 ? null : (
-                                <SelectField
-                                    key={adder.xmlid}
-                                    label={adder.display}
-                                    value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
-                                    options={adder.options.map((option) => option.display)}
-                                    onChange={(display) => setNested({option: adder.options.find((option) => option.display === display)?.xmlid})}
-                                    testID={`author-modifier-adder-${modifierId}-${adder.xmlid}`}
-                                />
-                            );
-                        })}
-                    </View>
-                );
-            })}
-
-            <SelectField label="Add advantage or limitation" value="" options={available.map((entry) => entry.display)} onChange={add} testID={`author-add-modifier-${id}`} />
-        </View>
-    );
-}
-
 const FRAMEWORK_KINDS: Array<{value: FrameworkKind; label: string}> = [
     {value: 'multipower', label: 'Multipower'},
     {value: 'elementalControl', label: 'Elemental Control'},
@@ -687,13 +464,24 @@ const FRAMEWORK_KINDS: Array<{value: FrameworkKind; label: string}> = [
 /**
  * Power frameworks: a pool, and the powers drawing on it.
  *
- * Its own section rather than a kind of power, because a framework is not priced like one — the
- * container costs its reserve and each slot a fraction of what it would cost alone. Slots reuse
- * {@link TraitRow}, so a power in a pool is edited exactly like a power outside one.
+ * The pool's own fields stay here — a name and a reserve are two lines, and a framework is mostly
+ * its contents. Each slot is a row that opens the same trait form a standalone power uses.
  */
-function Frameworks({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
+function Frameworks({
+    draft,
+    onChange,
+    character,
+    onEdit,
+    onEditPool,
+}: {
+    draft: AuthoredCharacter;
+    onChange: (draft: AuthoredCharacter) => void;
+    character: Obj | null;
+    onEdit: (address: TraitAddress, category: AuthorableCategory) => void;
+    onEditPool: (index: number) => void;
+}): React.JSX.Element {
     const powers = useMemo(() => authorable('powers', draft.edition), [draft.edition]);
-    const byXmlid = useMemo(() => new Map(catalogue('powers', draft.edition).map((entry) => [entry.xmlid, entry])), [draft.edition]);
+    const rows = character === null ? [] : frameworkSummaries(character);
 
     const update = (index: number, revised: AuthoredFramework): void =>
         onChange({...draft, frameworks: draft.frameworks.map((entry, position) => (position === index ? revised : entry))});
@@ -725,7 +513,13 @@ function Frameworks({draft, onChange}: {draft: AuthoredCharacter; onChange: (dra
                             />
                         </View>
 
-                        <TextField label="Name" value={framework.name} onChangeText={(name) => update(index, {...framework, name})} maxLength={60} testID={`author-framework-name-${index}`} />
+                        <TextField
+                            label="Name"
+                            value={framework.name}
+                            onChangeText={(name) => update(index, {...framework, name})}
+                            maxLength={60}
+                            testID={`author-framework-name-${index}`}
+                        />
 
                         <NumberField
                             label={framework.kind === 'vpp' ? 'Pool' : 'Reserve'}
@@ -734,29 +528,23 @@ function Frameworks({draft, onChange}: {draft: AuthoredCharacter; onChange: (dra
                             testID={`author-framework-reserve-${index}`}
                         />
 
-                        <Modifiers
-                            id={`framework-${index}`}
-                            edition={draft.edition}
-                            power={{xmlid: 'GENERIC_OBJECT', input: '', adders: [], modifiers: framework.modifiers} as AuthoredPower}
-                            onChange={(revised) => update(index, {...framework, modifiers: (revised as AuthoredPower).modifiers})}
+                        <Button
+                            label="Advantages & limitations"
+                            onPress={() => onEditPool(index)}
+                            variant="secondary"
+                            testID={`author-edit-framework-${index}`}
                         />
 
-                        {framework.slots.map((slot, order) => {
-                            const entry = byXmlid.get(slot.xmlid);
-
-                            return entry === undefined ? null : (
-                                <TraitRow
-                                    key={`${slot.xmlid}-${order}`}
-                                    index={order}
-                                    draftKey={`framework-${index}-slot`}
-                                    edition={draft.edition}
-                                    entry={entry}
-                                    trait={slot}
-                                    onChange={(revised) => update(index, {...framework, slots: framework.slots.map((entry2, p) => (p === order ? (revised as AuthoredPower) : entry2))})}
-                                    onRemove={() => update(index, {...framework, slots: framework.slots.filter((_, p) => p !== order)})}
-                                />
-                            );
-                        })}
+                        {framework.slots.map((slot, order) => (
+                            <TraitListRow
+                                key={`${slot.xmlid}-${order}`}
+                                label={rows[index]?.slots[order]?.label ?? slot.xmlid}
+                                cost={rows[index]?.slots[order]?.cost ?? 0}
+                                onPress={() => onEdit({kind: 'slot', framework: index, index: order}, 'powers')}
+                                testID={`author-row-framework-${index}-slot-${order}`}
+                                indented
+                            />
+                        ))}
 
                         <SelectField
                             label="Add a power to this framework"
@@ -770,9 +558,17 @@ function Frameworks({draft, onChange}: {draft: AuthoredCharacter; onChange: (dra
                                         ...framework,
                                         slots: [
                                             ...framework.slots,
-                                            {xmlid: entry.xmlid, input: '', adders: [], levels: 0, modifiers: [], ...(entry.fieldGroup === null ? {} : {defense: {pd: 0, ed: 0, mental: 0, power: 0}})},
+                                            {
+                                                xmlid: entry.xmlid,
+                                                input: '',
+                                                adders: [],
+                                                levels: 0,
+                                                modifiers: [],
+                                                ...(entry.fieldGroup === null ? {} : {defense: {pd: 0, ed: 0, mental: 0, power: 0}}),
+                                            },
                                         ],
                                     });
+                                    onEdit({kind: 'slot', framework: index, index: framework.slots.length}, 'powers');
                                 }
                             }}
                             testID={`author-add-slot-${index}`}
@@ -811,8 +607,7 @@ function Problems({problems}: {problems: readonly Problem[]}): React.JSX.Element
                     <Text
                         key={`${problem.path}-${index}`}
                         color={problem.severity === 'error' ? theme.colors.danger : theme.colors.textMuted}
-                        testID={`author-problem-${problem.severity}-${index}`}
-                    >
+                        testID={`author-problem-${problem.severity}-${index}`}>
                         {problem.message}
                     </Text>
                 ))}
@@ -844,6 +639,20 @@ const styles = StyleSheet.create({
     },
     complication: {
         rowGap: 8,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        columnGap: 12,
+        paddingVertical: 10,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+    },
+    rowIndented: {
+        paddingLeft: 16,
+    },
+    rowLabel: {
+        flex: 1,
     },
     modifiers: {
         rowGap: 8,

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -1,0 +1,459 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Authoring a character (docs/CHARACTER_AUTHORING.md).
+ *
+ * The screen holds a draft in local state and rebuilds the character on every change, so the
+ * points meter is the engine's own answer rather than a running tally kept alongside it. That
+ * costs a `getCharacter` per keystroke-commit, which at this size is far cheaper than the class of
+ * bug where the meter and the sheet disagree.
+ *
+ * **Every field here is generated from the rules templates.** The complication list, the prompts,
+ * the option pickers and their costs all come from `core/authoring`'s catalogue — nothing about
+ * Psychological Complications or Hunteds is written into this file. That is what makes Phase B
+ * (skills, powers) mostly a matter of pointing the same components at more catalogue.
+ */
+import React, {useCallback, useMemo, useState} from 'react';
+import {Alert, ScrollView, StyleSheet, View} from 'react-native';
+import {
+    build,
+    complications as catalogueComplications,
+    characteristics as catalogueCharacteristics,
+    DEFAULT_BUDGET,
+    emptyDraft,
+    isSaveable,
+    remaining,
+    spendOf,
+    validate,
+    type AuthoredCharacter,
+    type AuthoredComplication,
+    type AuthoringEdition,
+    type CatalogueComplication,
+    type Problem,
+} from 'core/authoring';
+import {Button, Card, NumberField, Screen, SegmentedControl, SelectField, Text, TextField} from 'app/components';
+import {useSaveAuthored} from 'app/providers/AuthoringProvider';
+import {useTheme} from 'app/theme';
+
+export interface AuthorCharacterScreenProps {
+    /** Re-open an existing authored character instead of starting fresh. */
+    initial?: AuthoredCharacter;
+    /** The row being edited, when there is one — a save without it creates a new character. */
+    characterId?: string;
+    onSaved: (id: string) => void;
+    onCancel: () => void;
+}
+
+const EDITIONS: Array<{value: AuthoringEdition; label: string}> = [
+    {value: '6E', label: '6th Edition'},
+    {value: '5E', label: '5th Edition'},
+];
+
+export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}: AuthorCharacterScreenProps): React.JSX.Element {
+    const save = useSaveAuthored();
+    const [draft, setDraft] = useState<AuthoredCharacter>(initial ?? emptyDraft('6E'));
+    const [busy, setBusy] = useState(false);
+
+    // The engine's answer, not a tally kept beside it. Rebuilt whenever the draft changes.
+    const {spend, problems} = useMemo(() => {
+        const validated = validate(draft);
+
+        // A draft with errors may not be buildable at all — an unknown characteristic throws
+        // rather than pricing at 0 — so the meter reads zero rather than crashing the screen.
+        if (!isSaveable(validated)) {
+            return {spend: null, problems: validated};
+        }
+
+        return {spend: spendOf(build(draft)), problems: validated};
+    }, [draft]);
+
+    const budget = DEFAULT_BUDGET[draft.edition];
+    const left = spend === null ? null : remaining(spend, budget, draft.edition);
+
+    const commit = useCallback(() => {
+        // Guarded here as well as on the button. Disabling a control is a UI affordance; refusing
+        // to write a character the engine cannot price is the actual rule, and it belongs on the
+        // path that does the writing.
+        if (busy || !isSaveable(problems)) {
+            return;
+        }
+
+        setBusy(true);
+        save(draft, characterId)
+            .then((result) => onSaved(result.id), (error: unknown) => Alert.alert('Could not save', error instanceof Error ? error.message : 'That character could not be saved.'))
+            .finally(() => setBusy(false));
+    }, [busy, problems, save, draft, characterId, onSaved]);
+
+    return (
+        <Screen>
+            <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+                <Card>
+                    <View style={styles.fields}>
+                        <Text variant="label" muted>
+                            {characterId === undefined ? 'NEW CHARACTER' : 'EDITING'}
+                        </Text>
+
+                        <TextField label="Name" value={draft.name} onChangeText={(name) => setDraft({...draft, name})} maxLength={60} testID="author-name" />
+                        <TextField label="Player" value={draft.player} onChangeText={(player) => setDraft({...draft, player})} maxLength={60} testID="author-player" />
+
+                        <EditionPicker draft={draft} onChange={setDraft} locked={characterId !== undefined} />
+                    </View>
+                </Card>
+
+                <SpendMeter left={left} complications={spend?.complications ?? 0} limit={budget.complicationLimit} edition={draft.edition} />
+
+                <Characteristics draft={draft} onChange={setDraft} />
+
+                <Complications draft={draft} onChange={setDraft} />
+
+                <Problems problems={problems} />
+
+                <View style={styles.actions}>
+                    <Button label="Cancel" onPress={onCancel} variant="secondary" testID="author-cancel" />
+                    <Button label={busy ? 'Saving…' : 'Save'} onPress={commit} disabled={busy || !isSaveable(problems)} testID="author-save" />
+                </View>
+            </ScrollView>
+        </Screen>
+    );
+}
+
+/**
+ * Changing edition resets the build.
+ *
+ * It has to: the two editions do not define the same characteristics (COM is 5E-only, the combat
+ * values 6E-only) and do not share complication entries, so carrying a 6E draft into 5E would
+ * produce a character referring to things that no longer exist. Locked once saved, because the
+ * stored document was priced by one rulebook and re-pricing it under the other is a new character,
+ * not an edit.
+ */
+function EditionPicker({draft, onChange, locked}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void; locked: boolean}): React.JSX.Element | null {
+    if (locked) {
+        return (
+            <View>
+                <Text variant="caption" muted>
+                    Edition
+                </Text>
+                <Text testID="author-edition-locked">{draft.edition === '5E' ? '5th Edition' : '6th Edition'}</Text>
+            </View>
+        );
+    }
+
+    return (
+        <View>
+            <Text variant="caption" muted>
+                Edition
+            </Text>
+            <SegmentedControl
+                segments={EDITIONS.map((edition) => ({value: edition.value, label: edition.label}))}
+                value={draft.edition}
+                onChange={(edition) => onChange({...emptyDraft(edition as AuthoringEdition), name: draft.name, player: draft.player})}
+            />
+        </View>
+    );
+}
+
+/** The running total: what is spent, what is left, and how the complications count. */
+function SpendMeter({
+    left,
+    complications,
+    limit,
+    edition,
+}: {
+    left: ReturnType<typeof remaining> | null;
+    complications: number;
+    limit: number;
+    edition: AuthoringEdition;
+}): React.JSX.Element {
+    const theme = useTheme();
+
+    if (left === null) {
+        return (
+            <Card>
+                <Text testID="author-spend">Points unavailable until the errors below are fixed.</Text>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <View style={styles.meter}>
+                <Text variant="label" muted>
+                    POINTS
+                </Text>
+                <Text testID="author-spend">
+                    {left.spent} spent of {left.total}
+                </Text>
+                <Text color={left.left < 0 ? theme.colors.danger : theme.colors.textMuted} testID="author-remaining">
+                    {left.left < 0 ? `${-left.left} over budget` : `${left.left} remaining`}
+                </Text>
+                <Text variant="caption" muted testID="author-complications-total">
+                    {/* The edition fork stated in words, because the same number means opposite
+                        things: 5E disadvantages buy points, 6E complications are a requirement. */}
+                    {edition === '5E'
+                        ? `Disadvantages ${complications} of ${limit} (they fund the build)`
+                        : `Complications ${complications} of ${limit} required (they grant no points)`}
+                </Text>
+            </View>
+        </Card>
+    );
+}
+
+/** Characteristic spinners, one per characteristic the edition defines. */
+function Characteristics({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
+    const catalogue = useMemo(() => catalogueCharacteristics(draft.edition), [draft.edition]);
+
+    const set = (key: string, text: string): void => {
+        const characteristics = {...draft.characteristics};
+
+        // An empty field means "leave it at base", which is not the same as zero — and typing over
+        // a value goes through empty on the way, so this must not be an error state.
+        if (text.trim() === '') {
+            delete characteristics[key];
+        } else {
+            const total = Number.parseInt(text, 10);
+
+            if (Number.isNaN(total)) {
+                return;
+            }
+
+            characteristics[key] = total;
+        }
+
+        onChange({...draft, characteristics});
+    };
+
+    return (
+        <Card>
+            <Text variant="label" muted>
+                CHARACTERISTICS
+            </Text>
+            <View style={styles.grid}>
+                {catalogue.map((entry) => (
+                    <View key={entry.key} style={styles.gridCell}>
+                        <NumberField
+                            label={`${entry.name} (${entry.base})`}
+                            value={draft.characteristics[entry.key] === undefined ? '' : String(draft.characteristics[entry.key])}
+                            onChangeText={(text) => set(entry.key, text)}
+                            placeholder={String(entry.base)}
+                            testID={`author-char-${entry.key}`}
+                        />
+                    </View>
+                ))}
+            </View>
+        </Card>
+    );
+}
+
+/** The complications list, every field of it generated from the template. */
+function Complications({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
+    const catalogue = useMemo(() => catalogueComplications(draft.edition), [draft.edition]);
+    const byXmlid = useMemo(() => new Map(catalogue.map((entry) => [entry.xmlid, entry])), [catalogue]);
+
+    const add = (display: string): void => {
+        const entry = catalogue.find((candidate) => candidate.display === display);
+
+        if (entry === undefined) {
+            return;
+        }
+
+        onChange({...draft, complications: [...draft.complications, {xmlid: entry.xmlid, input: '', adders: []}]});
+    };
+
+    const update = (index: number, complication: AuthoredComplication): void =>
+        onChange({...draft, complications: draft.complications.map((entry, position) => (position === index ? complication : entry))});
+
+    const remove = (index: number): void => onChange({...draft, complications: draft.complications.filter((_, position) => position !== index)});
+
+    return (
+        <Card>
+            <Text variant="label" muted>
+                {draft.edition === '5E' ? 'DISADVANTAGES' : 'COMPLICATIONS'}
+            </Text>
+
+            <View style={styles.fields}>
+                {draft.complications.map((complication, index) => {
+                    const entry = byXmlid.get(complication.xmlid);
+
+                    return entry === undefined ? (
+                        <Text key={`${complication.xmlid}-${index}`} testID={`author-complication-unknown-${index}`}>
+                            {draft.edition} has no “{complication.xmlid}”.
+                        </Text>
+                    ) : (
+                        <ComplicationRow
+                            key={`${complication.xmlid}-${index}`}
+                            index={index}
+                            entry={entry}
+                            complication={complication}
+                            onChange={(revised) => update(index, revised)}
+                            onRemove={() => remove(index)}
+                        />
+                    );
+                })}
+
+                <SelectField
+                    label="Add"
+                    value=""
+                    options={catalogue.map((entry) => entry.display)}
+                    onChange={add}
+                    hint={draft.edition === '5E' ? 'Disadvantages fund the build' : 'Complications are required, and grant no points'}
+                    testID="author-add-complication"
+                />
+            </View>
+        </Card>
+    );
+}
+
+/** One complication: its free text, then a control per adder the template declares. */
+function ComplicationRow({
+    index,
+    entry,
+    complication,
+    onChange,
+    onRemove,
+}: {
+    index: number;
+    entry: CatalogueComplication;
+    complication: AuthoredComplication;
+    onChange: (complication: AuthoredComplication) => void;
+    onRemove: () => void;
+}): React.JSX.Element {
+    const setAdder = (xmlid: string, patch: {option?: string; text?: string; levels?: number}): void => {
+        const existing = complication.adders.find((adder) => adder.xmlid === xmlid);
+        const adders = existing === undefined ? [...complication.adders, {xmlid, ...patch}] : complication.adders.map((adder) => (adder.xmlid === xmlid ? {...adder, ...patch} : adder));
+
+        onChange({...complication, adders});
+    };
+
+    return (
+        <View style={styles.complication}>
+            <View style={styles.complicationHead}>
+                <Text variant="label">{entry.display}</Text>
+                <Button label="Remove" onPress={onRemove} variant="secondary" testID={`author-remove-complication-${index}`} />
+            </View>
+
+            {entry.inputLabel === null ? null : (
+                <TextField
+                    label={entry.inputLabel}
+                    value={complication.input}
+                    onChangeText={(input) => onChange({...complication, input})}
+                    maxLength={80}
+                    testID={`author-complication-input-${index}`}
+                />
+            )}
+
+            {entry.levels === null ? null : (
+                <NumberField
+                    label={entry.levels.label}
+                    value={complication.levels === undefined ? '' : String(complication.levels)}
+                    onChangeText={(text) => onChange({...complication, levels: text.trim() === '' ? undefined : Number.parseInt(text, 10) || 0})}
+                    testID={`author-complication-levels-${index}`}
+                />
+            )}
+
+            {entry.adders.map((adder) => {
+                const chosen = complication.adders.find((candidate) => candidate.xmlid === adder.xmlid);
+
+                if (adder.freeText) {
+                    return (
+                        <TextField
+                            key={adder.xmlid}
+                            label={adder.display}
+                            value={chosen?.text ?? ''}
+                            onChangeText={(text) => setAdder(adder.xmlid, {text})}
+                            maxLength={80}
+                            testID={`author-adder-${index}-${adder.xmlid}`}
+                        />
+                    );
+                }
+
+                if (adder.options.length === 0) {
+                    return null; // a flat yes/no adder — Phase B, alongside the same control on powers
+                }
+
+                return (
+                    <SelectField
+                        key={adder.xmlid}
+                        label={adder.required ? adder.display : `${adder.display} (optional)`}
+                        value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
+                        options={adder.options.map((option) => option.display)}
+                        onChange={(display) => setAdder(adder.xmlid, {option: adder.options.find((option) => option.display === display)?.xmlid})}
+                        testID={`author-adder-${index}-${adder.xmlid}`}
+                    />
+                );
+            })}
+        </View>
+    );
+}
+
+/** Errors first, then advice. Errors block the save; warnings never do. */
+function Problems({problems}: {problems: readonly Problem[]}): React.JSX.Element | null {
+    const theme = useTheme();
+
+    if (problems.length === 0) {
+        return null;
+    }
+
+    return (
+        <Card>
+            <View style={styles.fields}>
+                {problems.map((problem, index) => (
+                    <Text
+                        key={`${problem.path}-${index}`}
+                        color={problem.severity === 'error' ? theme.colors.danger : theme.colors.textMuted}
+                        testID={`author-problem-${problem.severity}-${index}`}
+                    >
+                        {problem.message}
+                    </Text>
+                ))}
+            </View>
+        </Card>
+    );
+}
+
+const styles = StyleSheet.create({
+    content: {
+        padding: 16,
+        rowGap: 16,
+    },
+    fields: {
+        rowGap: 12,
+    },
+    meter: {
+        rowGap: 4,
+    },
+    grid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 12,
+        marginTop: 8,
+    },
+    gridCell: {
+        width: '30%',
+    },
+    complication: {
+        rowGap: 8,
+    },
+    complicationHead: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    actions: {
+        flexDirection: 'row',
+        columnGap: 12,
+        justifyContent: 'flex-end',
+    },
+});

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -317,8 +317,10 @@ function SpendMeter({
                 <Text testID="author-spend">
                     {left.spent} spent of {left.total}
                 </Text>
-                <Text color={left.left < 0 ? theme.colors.danger : theme.colors.textMuted} testID="author-remaining">
-                    {left.left < 0 ? `${-left.left} over budget` : `${left.left} remaining`}
+                {/* Past the allowance is not an overspend — it is earned experience, and the
+                    sheet's nameplate prints it beside the base. So it reads as a fact, not a fault. */}
+                <Text color={left.experience > 0 ? theme.colors.primary : theme.colors.textMuted} testID="author-remaining">
+                    {left.experience > 0 ? `${left.experience} experience` : `${left.left} remaining`}
                 </Text>
                 <Text variant="caption" muted testID="author-complications-total">
                     {/* The edition fork stated in words, because the same number means opposite

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -28,8 +28,9 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {Alert, ScrollView, StyleSheet, View} from 'react-native';
 import {
+    authorable,
     build,
-    complications as catalogueComplications,
+    catalogue,
     characteristics as catalogueCharacteristics,
     DEFAULT_BUDGET,
     emptyDraft,
@@ -37,10 +38,12 @@ import {
     remaining,
     spendOf,
     validate,
+    withheld,
+    type AuthorableCategory,
     type AuthoredCharacter,
-    type AuthoredComplication,
+    type AuthoredTrait,
     type AuthoringEdition,
-    type CatalogueComplication,
+    type CatalogueTrait,
     type Problem,
 } from 'core/authoring';
 import {Button, Card, NumberField, Screen, SegmentedControl, SelectField, Text, TextField} from 'app/components';
@@ -116,7 +119,16 @@ export function AuthorCharacterScreen({initial, characterId, onSaved, onCancel}:
 
                 <Characteristics draft={draft} onChange={setDraft} />
 
-                <Complications draft={draft} onChange={setDraft} />
+                {SECTIONS.map((section) => (
+                    <TraitSection
+                        key={section.key}
+                        category={section.category}
+                        draftKey={section.key}
+                        title={section.title(draft.edition)}
+                        draft={draft}
+                        onChange={setDraft}
+                    />
+                ))}
 
                 <Problems problems={problems} />
 
@@ -212,7 +224,7 @@ function SpendMeter({
 
 /** Characteristic spinners, one per characteristic the edition defines. */
 function Characteristics({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
-    const catalogue = useMemo(() => catalogueCharacteristics(draft.edition), [draft.edition]);
+    const entries = useMemo(() => catalogueCharacteristics(draft.edition), [draft.edition]);
 
     const set = (key: string, text: string): void => {
         const characteristics = {...draft.characteristics};
@@ -240,7 +252,7 @@ function Characteristics({draft, onChange}: {draft: AuthoredCharacter; onChange:
                 CHARACTERISTICS
             </Text>
             <View style={styles.grid}>
-                {catalogue.map((entry) => (
+                {entries.map((entry) => (
                     <View key={entry.key} style={styles.gridCell}>
                         <NumberField
                             label={`${entry.name} (${entry.base})`}
@@ -256,46 +268,91 @@ function Characteristics({draft, onChange}: {draft: AuthoredCharacter; onChange:
     );
 }
 
-/** The complications list, every field of it generated from the template. */
-function Complications({draft, onChange}: {draft: AuthoredCharacter; onChange: (draft: AuthoredCharacter) => void}): React.JSX.Element {
-    const catalogue = useMemo(() => catalogueComplications(draft.edition), [draft.edition]);
-    const byXmlid = useMemo(() => new Map(catalogue.map((entry) => [entry.xmlid, entry])), [catalogue]);
+/** How each authorable category is titled and stored on the draft. */
+const SECTIONS: Array<{category: AuthorableCategory; key: 'skills' | 'perks' | 'talents' | 'complications'; title: (edition: AuthoringEdition) => string}> = [
+    {category: 'skills', key: 'skills', title: () => 'SKILLS'},
+    {category: 'perks', key: 'perks', title: () => 'PERKS'},
+    {category: 'talents', key: 'talents', title: () => 'TALENTS'},
+    // The rules rename them between editions, and so does the sheet.
+    {category: 'disadvantages', key: 'complications', title: (edition) => (edition === '5E' ? 'DISADVANTAGES' : 'COMPLICATIONS')},
+];
+
+/**
+ * One category's list, every field of it generated from the template.
+ *
+ * This component is the whole of Phase B's UI. Skills, perks, talents and complications differ in
+ * which fields their template entries declare, not in kind, so there is one renderer and the
+ * catalogue decides what it draws.
+ */
+function TraitSection({
+    category,
+    draftKey,
+    title,
+    draft,
+    onChange,
+}: {
+    category: AuthorableCategory;
+    draftKey: 'skills' | 'perks' | 'talents' | 'complications';
+    title: string;
+    draft: AuthoredCharacter;
+    onChange: (draft: AuthoredCharacter) => void;
+}): React.JSX.Element {
+    const offered = useMemo(() => authorable(category, draft.edition), [category, draft.edition]);
+    const notYet = useMemo(() => withheld(category, draft.edition), [category, draft.edition]);
+    const byXmlid = useMemo(() => new Map(catalogue(category, draft.edition).map((entry) => [entry.xmlid, entry])), [category, draft.edition]);
+    const taken = draft[draftKey];
 
     const add = (display: string): void => {
-        const entry = catalogue.find((candidate) => candidate.display === display);
+        const entry = offered.find((candidate) => candidate.display === display);
 
         if (entry === undefined) {
             return;
         }
 
-        onChange({...draft, complications: [...draft.complications, {xmlid: entry.xmlid, input: '', adders: []}]});
+        // Seeded with the only unambiguous answers: a lone characteristic choice, and levels at
+        // zero. Anything the player must decide is left blank so `validate` asks for it rather
+        // than the form quietly picking.
+        onChange({
+            ...draft,
+            [draftKey]: [
+                ...taken,
+                {
+                    xmlid: entry.xmlid,
+                    input: '',
+                    adders: [],
+                    levels: 0,
+                    ...(entry.characteristics.length === 1 ? {characteristic: entry.characteristics[0].characteristic} : {}),
+                },
+            ],
+        });
     };
 
-    const update = (index: number, complication: AuthoredComplication): void =>
-        onChange({...draft, complications: draft.complications.map((entry, position) => (position === index ? complication : entry))});
+    const update = (index: number, revised: AuthoredTrait): void =>
+        onChange({...draft, [draftKey]: taken.map((entry, position) => (position === index ? revised : entry))});
 
-    const remove = (index: number): void => onChange({...draft, complications: draft.complications.filter((_, position) => position !== index)});
+    const remove = (index: number): void => onChange({...draft, [draftKey]: taken.filter((_, position) => position !== index)});
 
     return (
         <Card>
             <Text variant="label" muted>
-                {draft.edition === '5E' ? 'DISADVANTAGES' : 'COMPLICATIONS'}
+                {title}
             </Text>
 
             <View style={styles.fields}>
-                {draft.complications.map((complication, index) => {
-                    const entry = byXmlid.get(complication.xmlid);
+                {taken.map((entry, index) => {
+                    const catalogueEntry = byXmlid.get(entry.xmlid);
 
-                    return entry === undefined ? (
-                        <Text key={`${complication.xmlid}-${index}`} testID={`author-complication-unknown-${index}`}>
-                            {draft.edition} has no “{complication.xmlid}”.
+                    return catalogueEntry === undefined ? (
+                        <Text key={`${entry.xmlid}-${index}`} testID={`author-${draftKey}-unknown-${index}`}>
+                            {draft.edition} has no “{entry.xmlid}”.
                         </Text>
                     ) : (
-                        <ComplicationRow
-                            key={`${complication.xmlid}-${index}`}
+                        <TraitRow
+                            key={`${entry.xmlid}-${index}`}
                             index={index}
-                            entry={entry}
-                            complication={complication}
+                            draftKey={draftKey}
+                            entry={catalogueEntry}
+                            trait={entry}
                             onChange={(revised) => update(index, revised)}
                             onRemove={() => remove(index)}
                         />
@@ -305,65 +362,104 @@ function Complications({draft, onChange}: {draft: AuthoredCharacter; onChange: (
                 <SelectField
                     label="Add"
                     value=""
-                    options={catalogue.map((entry) => entry.display)}
+                    options={offered.map((entry) => entry.display)}
                     onChange={add}
-                    hint={draft.edition === '5E' ? 'Disadvantages fund the build' : 'Complications are required, and grant no points'}
-                    testID="author-add-complication"
+                    // Said rather than silently omitted: a shorter list reads as "the app lacks
+                    // Weapon Familiarity", not "not yet". See docs/CHARACTER_AUTHORING.md.
+                    hint={notYet.length === 0 ? undefined : `${notYet.length} more need a form of their own`}
+                    testID={`author-add-${draftKey}`}
                 />
             </View>
         </Card>
     );
 }
 
-/** One complication: its free text, then a control per adder the template declares. */
-function ComplicationRow({
+/** One trait: whichever of free text, characteristic, option, levels, familiarity and adders it declares. */
+function TraitRow({
     index,
+    draftKey,
     entry,
-    complication,
+    trait,
     onChange,
     onRemove,
 }: {
     index: number;
-    entry: CatalogueComplication;
-    complication: AuthoredComplication;
-    onChange: (complication: AuthoredComplication) => void;
+    draftKey: string;
+    entry: CatalogueTrait;
+    trait: AuthoredTrait;
+    onChange: (trait: AuthoredTrait) => void;
     onRemove: () => void;
 }): React.JSX.Element {
-    const setAdder = (xmlid: string, patch: {option?: string; text?: string; levels?: number}): void => {
-        const existing = complication.adders.find((adder) => adder.xmlid === xmlid);
-        const adders = existing === undefined ? [...complication.adders, {xmlid, ...patch}] : complication.adders.map((adder) => (adder.xmlid === xmlid ? {...adder, ...patch} : adder));
+    const id = `${draftKey}-${index}`;
 
-        onChange({...complication, adders});
+    const setAdder = (xmlid: string, patch: {option?: string; text?: string; levels?: number}): void => {
+        const existing = trait.adders.find((adder) => adder.xmlid === xmlid);
+        const adders = existing === undefined ? [...trait.adders, {xmlid, ...patch}] : trait.adders.map((adder) => (adder.xmlid === xmlid ? {...adder, ...patch} : adder));
+
+        onChange({...trait, adders});
     };
 
     return (
         <View style={styles.complication}>
             <View style={styles.complicationHead}>
                 <Text variant="label">{entry.display}</Text>
-                <Button label="Remove" onPress={onRemove} variant="secondary" testID={`author-remove-complication-${index}`} />
+                <Button label="Remove" onPress={onRemove} variant="secondary" testID={`author-remove-${id}`} />
             </View>
 
             {entry.inputLabel === null ? null : (
-                <TextField
-                    label={entry.inputLabel}
-                    value={complication.input}
-                    onChangeText={(input) => onChange({...complication, input})}
-                    maxLength={80}
-                    testID={`author-complication-input-${index}`}
+                <TextField label={entry.inputLabel} value={trait.input} onChangeText={(input) => onChange({...trait, input})} maxLength={80} testID={`author-input-${id}`} />
+            )}
+
+            {entry.familiarity === null ? null : (
+                <SegmentedControl
+                    segments={[
+                        {value: 'full', label: 'Full skill'},
+                        {value: 'familiarity', label: `Familiarity (${entry.familiarity.roll}-)`},
+                    ]}
+                    value={trait.familiarity === true ? 'familiarity' : 'full'}
+                    // A familiarity is a different purchase, not the skill at zero — so switching
+                    // drops the characteristic and levels rather than keeping them around unused.
+                    onChange={(mode) =>
+                        onChange(
+                            mode === 'familiarity'
+                                ? {xmlid: trait.xmlid, input: trait.input, adders: trait.adders, familiarity: true}
+                                : {xmlid: trait.xmlid, input: trait.input, adders: trait.adders, levels: 0, ...(entry.characteristics.length === 1 ? {characteristic: entry.characteristics[0].characteristic} : {})},
+                        )
+                    }
                 />
             )}
 
-            {entry.levels === null ? null : (
+            {entry.characteristics.length > 1 && trait.familiarity !== true ? (
+                <SelectField
+                    label="Based on"
+                    value={trait.characteristic ?? ''}
+                    options={entry.characteristics.map((choice) => choice.characteristic)}
+                    onChange={(characteristic) => onChange({...trait, characteristic})}
+                    testID={`author-characteristic-${id}`}
+                />
+            ) : null}
+
+            {entry.options.length === 0 ? null : (
+                <SelectField
+                    label={entry.display}
+                    value={entry.options.find((option) => option.xmlid === trait.option)?.display ?? ''}
+                    options={entry.options.map((option) => option.display)}
+                    onChange={(display) => onChange({...trait, option: entry.options.find((option) => option.display === display)?.xmlid})}
+                    testID={`author-option-${id}`}
+                />
+            )}
+
+            {entry.levels === null || trait.familiarity === true ? null : (
                 <NumberField
                     label={entry.levels.label}
-                    value={complication.levels === undefined ? '' : String(complication.levels)}
-                    onChangeText={(text) => onChange({...complication, levels: text.trim() === '' ? undefined : Number.parseInt(text, 10) || 0})}
-                    testID={`author-complication-levels-${index}`}
+                    value={trait.levels === undefined ? '' : String(trait.levels)}
+                    onChangeText={(text) => onChange({...trait, levels: text.trim() === '' ? 0 : Math.max(0, Number.parseInt(text, 10) || 0)})}
+                    testID={`author-levels-${id}`}
                 />
             )}
 
             {entry.adders.map((adder) => {
-                const chosen = complication.adders.find((candidate) => candidate.xmlid === adder.xmlid);
+                const chosen = trait.adders.find((candidate) => candidate.xmlid === adder.xmlid);
 
                 if (adder.freeText) {
                     return (
@@ -373,13 +469,13 @@ function ComplicationRow({
                             value={chosen?.text ?? ''}
                             onChangeText={(text) => setAdder(adder.xmlid, {text})}
                             maxLength={80}
-                            testID={`author-adder-${index}-${adder.xmlid}`}
+                            testID={`author-adder-${id}-${adder.xmlid}`}
                         />
                     );
                 }
 
                 if (adder.options.length === 0) {
-                    return null; // a flat yes/no adder — Phase B, alongside the same control on powers
+                    return null; // a flat yes/no adder — needs a switch, which is its own change
                 }
 
                 return (
@@ -389,7 +485,7 @@ function ComplicationRow({
                         value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
                         options={adder.options.map((option) => option.display)}
                         onChange={(display) => setAdder(adder.xmlid, {option: adder.options.find((option) => option.display === display)?.xmlid})}
-                        testID={`author-adder-${index}-${adder.xmlid}`}
+                        testID={`author-adder-${id}-${adder.xmlid}`}
                     />
                 );
             })}

--- a/src/app/screens/AuthorCharacterScreen.tsx
+++ b/src/app/screens/AuthorCharacterScreen.tsx
@@ -38,12 +38,16 @@ import {
     remaining,
     spendOf,
     validate,
+    modifiers,
     withheld,
     type AuthorableCategory,
     type AuthoredCharacter,
+    type AuthoredModifier,
+    type AuthoredPower,
     type AuthoredTrait,
     type AuthoringEdition,
     type CatalogueTrait,
+    type FieldGroup,
     type Problem,
 } from 'core/authoring';
 import {Button, Card, NumberField, Screen, SegmentedControl, SelectField, Text, TextField} from 'app/components';
@@ -269,10 +273,13 @@ function Characteristics({draft, onChange}: {draft: AuthoredCharacter; onChange:
 }
 
 /** How each authorable category is titled and stored on the draft. */
-const SECTIONS: Array<{category: AuthorableCategory; key: 'skills' | 'perks' | 'talents' | 'complications'; title: (edition: AuthoringEdition) => string}> = [
+type DraftKey = 'skills' | 'perks' | 'talents' | 'powers' | 'complications';
+
+const SECTIONS: Array<{category: AuthorableCategory; key: DraftKey; title: (edition: AuthoringEdition) => string}> = [
     {category: 'skills', key: 'skills', title: () => 'SKILLS'},
     {category: 'perks', key: 'perks', title: () => 'PERKS'},
     {category: 'talents', key: 'talents', title: () => 'TALENTS'},
+    {category: 'powers', key: 'powers', title: () => 'POWERS'},
     // The rules rename them between editions, and so does the sheet.
     {category: 'disadvantages', key: 'complications', title: (edition) => (edition === '5E' ? 'DISADVANTAGES' : 'COMPLICATIONS')},
 ];
@@ -292,7 +299,7 @@ function TraitSection({
     onChange,
 }: {
     category: AuthorableCategory;
-    draftKey: 'skills' | 'perks' | 'talents' | 'complications';
+    draftKey: DraftKey;
     title: string;
     draft: AuthoredCharacter;
     onChange: (draft: AuthoredCharacter) => void;
@@ -322,6 +329,8 @@ function TraitSection({
                     adders: [],
                     levels: 0,
                     ...(entry.characteristics.length === 1 ? {characteristic: entry.characteristics[0].characteristic} : {}),
+                    ...(entry.modifiable ? {modifiers: []} : {}),
+                    ...(entry.fieldGroup === null ? {} : {defense: {pd: 0, ed: 0, mental: 0, power: 0}}),
                 },
             ],
         });
@@ -351,6 +360,7 @@ function TraitSection({
                             key={`${entry.xmlid}-${index}`}
                             index={index}
                             draftKey={draftKey}
+                            edition={draft.edition}
                             entry={catalogueEntry}
                             trait={entry}
                             onChange={(revised) => update(index, revised)}
@@ -378,6 +388,7 @@ function TraitSection({
 function TraitRow({
     index,
     draftKey,
+    edition,
     entry,
     trait,
     onChange,
@@ -385,6 +396,7 @@ function TraitRow({
 }: {
     index: number;
     draftKey: string;
+    edition: AuthoringEdition;
     entry: CatalogueTrait;
     trait: AuthoredTrait;
     onChange: (trait: AuthoredTrait) => void;
@@ -406,9 +418,17 @@ function TraitRow({
                 <Button label="Remove" onPress={onRemove} variant="secondary" testID={`author-remove-${id}`} />
             </View>
 
+            {/* Only powers are named. A skill's label is its own name; a power's is whatever the
+                player called it — "Fire Bolt (Blast)". */}
+            {entry.modifiable ? (
+                <TextField label="Name" value={trait.name ?? ''} onChangeText={(name) => onChange({...trait, name})} maxLength={60} testID={`author-name-${id}`} />
+            ) : null}
+
             {entry.inputLabel === null ? null : (
                 <TextField label={entry.inputLabel} value={trait.input} onChangeText={(input) => onChange({...trait, input})} maxLength={80} testID={`author-input-${id}`} />
             )}
+
+            {entry.fieldGroup === null ? null : <DefenseFields id={id} group={entry.fieldGroup} trait={trait} onChange={onChange} />}
 
             {entry.familiarity === null ? null : (
                 <SegmentedControl
@@ -489,6 +509,163 @@ function TraitRow({
                     />
                 );
             })}
+
+            {entry.modifiable ? <Modifiers id={id} edition={edition} power={trait as AuthoredPower} onChange={onChange} /> : null}
+        </View>
+    );
+}
+
+/**
+ * The defences a Resistant Protection is split across.
+ *
+ * Four numbers with no template behind them — see `FieldGroup`. The power's `levels` is derived
+ * from their sum at emit time, so there is nothing here for the player to keep in step.
+ */
+function DefenseFields({
+    id,
+    group,
+    trait,
+    onChange,
+}: {
+    id: string;
+    group: FieldGroup;
+    trait: AuthoredTrait;
+    onChange: (trait: AuthoredTrait) => void;
+}): React.JSX.Element {
+    const defense = (trait as AuthoredPower).defense ?? {pd: 0, ed: 0, mental: 0, power: 0};
+
+    return (
+        <View>
+            <Text variant="caption" muted>
+                {group.label}
+            </Text>
+            <View style={styles.grid}>
+                {group.fields.map((field) => (
+                    <View key={field.key} style={styles.gridCell}>
+                        <NumberField
+                            label={field.label}
+                            value={String(defense[field.key])}
+                            onChangeText={(text) => onChange({...trait, defense: {...defense, [field.key]: Math.max(0, Number.parseInt(text, 10) || 0)}} as AuthoredTrait)}
+                            testID={`author-defense-${id}-${field.key}`}
+                        />
+                    </View>
+                ))}
+            </View>
+        </View>
+    );
+}
+
+/**
+ * A power's advantages and limitations.
+ *
+ * One list, not two, because which is which is the sign of what a modifier ends up costing rather
+ * than a property of the modifier — `ModifierCalculator` splits them on exactly that, and an
+ * option can flip a modifier from one to the other.
+ */
+function Modifiers({
+    id,
+    edition,
+    power,
+    onChange,
+}: {
+    id: string;
+    edition: AuthoringEdition;
+    power: AuthoredPower;
+    onChange: (trait: AuthoredTrait) => void;
+}): React.JSX.Element {
+    const available = useMemo(() => modifiers(edition), [edition]);
+    const byXmlid = useMemo(() => new Map(available.map((entry) => [entry.xmlid, entry])), [available]);
+
+    const add = (display: string): void => {
+        const entry = available.find((candidate) => candidate.display === display);
+
+        if (entry !== undefined) {
+            onChange({...power, modifiers: [...power.modifiers, {xmlid: entry.xmlid, adders: []}]} as AuthoredTrait);
+        }
+    };
+
+    const update = (index: number, revised: AuthoredModifier): void =>
+        onChange({...power, modifiers: power.modifiers.map((entry, position) => (position === index ? revised : entry))} as AuthoredTrait);
+
+    const remove = (index: number): void => onChange({...power, modifiers: power.modifiers.filter((_, position) => position !== index)} as AuthoredTrait);
+
+    return (
+        <View style={styles.modifiers}>
+            <Text variant="caption" muted>
+                Advantages &amp; limitations
+            </Text>
+
+            {power.modifiers.map((applied, index) => {
+                const entry = byXmlid.get(applied.xmlid);
+                const modifierId = `${id}-mod-${index}`;
+
+                return entry === undefined ? (
+                    <Text key={modifierId} testID={`author-modifier-unknown-${modifierId}`}>
+                        {edition} has no “{applied.xmlid}”.
+                    </Text>
+                ) : (
+                    <View key={modifierId} style={styles.complication}>
+                        <View style={styles.complicationHead}>
+                            <Text>{entry.display}</Text>
+                            <Button label="Remove" onPress={() => remove(index)} variant="secondary" testID={`author-remove-${modifierId}`} />
+                        </View>
+
+                        {entry.freeText ? (
+                            <TextField
+                                label={entry.display}
+                                value={applied.text ?? ''}
+                                onChangeText={(text) => update(index, {...applied, text})}
+                                maxLength={80}
+                                testID={`author-modifier-text-${modifierId}`}
+                            />
+                        ) : null}
+
+                        {entry.options.length === 0 ? null : (
+                            <SelectField
+                                label="Which"
+                                value={entry.options.find((option) => option.xmlid === applied.option)?.display ?? ''}
+                                options={entry.options.map((option) => option.display)}
+                                onChange={(display) => update(index, {...applied, option: entry.options.find((option) => option.display === display)?.xmlid})}
+                                testID={`author-modifier-option-${modifierId}`}
+                            />
+                        )}
+
+                        {entry.levels === null ? null : (
+                            <NumberField
+                                label={entry.levels.label}
+                                value={applied.levels === undefined ? '' : String(applied.levels)}
+                                onChangeText={(text) => update(index, {...applied, levels: text.trim() === '' ? 0 : Math.max(0, Number.parseInt(text, 10) || 0)})}
+                                testID={`author-modifier-levels-${modifierId}`}
+                            />
+                        )}
+
+                        {entry.adders.map((adder) => {
+                            const chosen = applied.adders.find((candidate) => candidate.xmlid === adder.xmlid);
+                            const setNested = (patch: {option?: string}): void =>
+                                update(index, {
+                                    ...applied,
+                                    adders:
+                                        chosen === undefined
+                                            ? [...applied.adders, {xmlid: adder.xmlid, ...patch}]
+                                            : applied.adders.map((candidate) => (candidate.xmlid === adder.xmlid ? {...candidate, ...patch} : candidate)),
+                                });
+
+                            return adder.options.length === 0 ? null : (
+                                <SelectField
+                                    key={adder.xmlid}
+                                    label={adder.display}
+                                    value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
+                                    options={adder.options.map((option) => option.display)}
+                                    onChange={(display) => setNested({option: adder.options.find((option) => option.display === display)?.xmlid})}
+                                    testID={`author-modifier-adder-${modifierId}-${adder.xmlid}`}
+                                />
+                            );
+                        })}
+                    </View>
+                );
+            })}
+
+            <SelectField label="Add advantage or limitation" value="" options={available.map((entry) => entry.display)} onChange={add} testID={`author-add-modifier-${id}`} />
         </View>
     );
 }
@@ -541,6 +718,10 @@ const styles = StyleSheet.create({
     },
     complication: {
         rowGap: 8,
+    },
+    modifiers: {
+        rowGap: 8,
+        marginTop: 4,
     },
     complicationHead: {
         flexDirection: 'row',

--- a/src/app/screens/AuthorTraitScreen.tsx
+++ b/src/app/screens/AuthorTraitScreen.tsx
@@ -1,0 +1,486 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Editing one trait, on its own screen (docs/CHARACTER_AUTHORING.md).
+ *
+ * A trait's form is not small — a power can carry a free-text field, an option, levels, a defence
+ * split, its adders, and any number of advantages and limitations, each with options and adders of
+ * their own. Rendering every trait's form inline made the authoring screen scroll for a very long
+ * way, so the list shows a row per trait and the form lives here.
+ *
+ * The draft is *not* passed in. It lives in {@link AuthoringDraftProvider}, and this screen is told
+ * only the address of the trait to edit — a route can carry that without anybody having to think
+ * about whether a whole character survives serialisation.
+ *
+ * Every field is generated from the rules templates. Nothing about Blast or Area Of Effect appears
+ * in this file; the catalogue says what a trait declares and this draws it.
+ */
+import React, {useMemo} from 'react';
+import {ScrollView, StyleSheet, View} from 'react-native';
+import {
+    modifiers,
+    trait as catalogueTrait,
+    type AuthoredModifier,
+    type AuthoredPower,
+    type AuthoredTrait,
+    type AuthoringEdition,
+    type CatalogueTrait,
+    type FieldGroup,
+} from 'core/authoring';
+import {Button, Card, NumberField, Screen, SegmentedControl, SelectField, Text, TextField} from 'app/components';
+import {useAuthoringDraft, type TraitAddress} from 'app/providers/AuthoringDraftProvider';
+
+export interface AuthorTraitScreenProps {
+    /** Which trait to edit. Stale addresses render an explanation rather than crashing. */
+    address: TraitAddress;
+    /** The catalogue category the trait is drawn from — equipment and powers share one. */
+    category: 'skills' | 'perks' | 'talents' | 'powers' | 'martialArts' | 'disadvantages';
+    onDone: () => void;
+}
+
+/**
+ * The form for one trait.
+ *
+ * An address can go stale — the trait behind it removed on the previous screen, or a draft
+ * reopened after a build that dropped the entry. Both render a note and a way out rather than
+ * throwing inside a screen the player cannot leave.
+ */
+export function AuthorTraitScreen({address, category, onDone}: AuthorTraitScreenProps): React.JSX.Element {
+    const {draft, traitAt, frameworkAt, replaceFramework, replaceAt, removeAt} = useAuthoringDraft();
+    const value = traitAt(address);
+    const entry = useMemo(() => (value === null ? null : catalogueTrait(value.xmlid, category, draft.edition)), [value, category, draft.edition]);
+    const pool = address.kind === 'pool' ? frameworkAt(address.framework) : null;
+
+    // A framework's pool carries advantages and limitations but is not a trait — it has no
+    // catalogue entry, no levels of its own and nothing to pick. Only the modifier editor applies.
+    if (address.kind === 'pool') {
+        return (
+            <Screen>
+                <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+                    <Card>
+                        {pool === null ? (
+                            <View style={styles.fields}>
+                                <Text testID="author-trait-missing">This framework is no longer part of the character.</Text>
+                                <Button label="Back" onPress={onDone} testID="author-trait-done" />
+                            </View>
+                        ) : (
+                            <Modifiers
+                                id={`framework-${address.framework}`}
+                                edition={draft.edition}
+                                power={{xmlid: 'GENERIC_OBJECT', input: '', adders: [], modifiers: pool.modifiers} as AuthoredPower}
+                                onChange={(revised) => replaceFramework(address.framework, {...pool, modifiers: (revised as AuthoredPower).modifiers})}
+                            />
+                        )}
+                    </Card>
+
+                    <View style={styles.actions}>
+                        <Button label="Done" onPress={onDone} testID="author-trait-done" />
+                    </View>
+                </ScrollView>
+            </Screen>
+        );
+    }
+
+    if (value === null || entry === null) {
+        return (
+            <Screen>
+                <ScrollView contentContainerStyle={styles.content}>
+                    <Card>
+                        <View style={styles.fields}>
+                            <Text testID="author-trait-missing">This trait is no longer part of the character.</Text>
+                            <Button label="Back" onPress={onDone} testID="author-trait-done" />
+                        </View>
+                    </Card>
+                </ScrollView>
+            </Screen>
+        );
+    }
+
+    return (
+        <Screen>
+            <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+                <Card>
+                    <TraitRow
+                        index={address.index}
+                        draftKey={address.kind === 'trait' ? address.key : `framework-${address.framework}-slot`}
+                        edition={draft.edition}
+                        entry={entry}
+                        trait={value}
+                        onChange={(revised) => replaceAt(address, revised)}
+                        onRemove={() => {
+                            removeAt(address);
+                            onDone();
+                        }}
+                    />
+                </Card>
+
+                <View style={styles.actions}>
+                    <Button label="Done" onPress={onDone} testID="author-trait-done" />
+                </View>
+            </ScrollView>
+        </Screen>
+    );
+}
+
+function TraitRow({
+    index,
+    draftKey,
+    edition,
+    entry,
+    trait,
+    onChange,
+    onRemove,
+}: {
+    index: number;
+    draftKey: string;
+    edition: AuthoringEdition;
+    entry: CatalogueTrait;
+    trait: AuthoredTrait;
+    onChange: (trait: AuthoredTrait) => void;
+    onRemove: () => void;
+}): React.JSX.Element {
+    const id = `${draftKey}-${index}`;
+
+    const setAdder = (xmlid: string, patch: {option?: string; text?: string; levels?: number}): void => {
+        const existing = trait.adders.find((adder) => adder.xmlid === xmlid);
+        const adders =
+            existing === undefined ? [...trait.adders, {xmlid, ...patch}] : trait.adders.map((adder) => (adder.xmlid === xmlid ? {...adder, ...patch} : adder));
+
+        onChange({...trait, adders});
+    };
+
+    return (
+        <View style={styles.complication}>
+            <View style={styles.complicationHead}>
+                <Text variant="label">{entry.display}</Text>
+                <Button label="Remove" onPress={onRemove} variant="secondary" testID={`author-remove-${id}`} />
+            </View>
+
+            {/* Only powers are named. A skill's label is its own name; a power's is whatever the
+                player called it — "Fire Bolt (Blast)". */}
+            {entry.modifiable ? (
+                <TextField
+                    label="Name"
+                    value={trait.name ?? ''}
+                    onChangeText={(name) => onChange({...trait, name})}
+                    maxLength={60}
+                    testID={`author-name-${id}`}
+                />
+            ) : null}
+
+            {entry.inputLabel === null ? null : (
+                <TextField
+                    label={entry.inputLabel}
+                    value={trait.input}
+                    onChangeText={(input) => onChange({...trait, input})}
+                    maxLength={80}
+                    testID={`author-input-${id}`}
+                />
+            )}
+
+            {entry.fieldGroup === null ? null : <DefenseFields id={id} group={entry.fieldGroup} trait={trait} onChange={onChange} />}
+
+            {entry.familiarity === null ? null : (
+                <SegmentedControl
+                    segments={[
+                        {value: 'full', label: 'Full skill'},
+                        {value: 'familiarity', label: `Familiarity (${entry.familiarity.roll}-)`},
+                    ]}
+                    value={trait.familiarity === true ? 'familiarity' : 'full'}
+                    // A familiarity is a different purchase, not the skill at zero — so switching
+                    // drops the characteristic and levels rather than keeping them around unused.
+                    onChange={(mode) =>
+                        onChange(
+                            mode === 'familiarity'
+                                ? {xmlid: trait.xmlid, input: trait.input, adders: trait.adders, familiarity: true}
+                                : {
+                                      xmlid: trait.xmlid,
+                                      input: trait.input,
+                                      adders: trait.adders,
+                                      levels: 0,
+                                      ...(entry.characteristics.length === 1 ? {characteristic: entry.characteristics[0].characteristic} : {}),
+                                  },
+                        )
+                    }
+                />
+            )}
+
+            {entry.characteristics.length > 1 && trait.familiarity !== true ? (
+                <SelectField
+                    label="Based on"
+                    value={trait.characteristic ?? ''}
+                    options={entry.characteristics.map((choice) => choice.characteristic)}
+                    onChange={(characteristic) => onChange({...trait, characteristic})}
+                    testID={`author-characteristic-${id}`}
+                />
+            ) : null}
+
+            {entry.options.length === 0 ? null : (
+                <SelectField
+                    label={entry.display}
+                    value={entry.options.find((option) => option.xmlid === trait.option)?.display ?? ''}
+                    options={entry.options.map((option) => option.display)}
+                    onChange={(display) => onChange({...trait, option: entry.options.find((option) => option.display === display)?.xmlid})}
+                    testID={`author-option-${id}`}
+                />
+            )}
+
+            {entry.levels === null || trait.familiarity === true ? null : (
+                <NumberField
+                    label={entry.levels.label}
+                    value={trait.levels === undefined ? '' : String(trait.levels)}
+                    onChangeText={(text) => onChange({...trait, levels: text.trim() === '' ? 0 : Math.max(0, Number.parseInt(text, 10) || 0)})}
+                    testID={`author-levels-${id}`}
+                />
+            )}
+
+            {entry.adders.map((adder) => {
+                const chosen = trait.adders.find((candidate) => candidate.xmlid === adder.xmlid);
+
+                if (adder.freeText) {
+                    return (
+                        <TextField
+                            key={adder.xmlid}
+                            label={adder.display}
+                            value={chosen?.text ?? ''}
+                            onChangeText={(text) => setAdder(adder.xmlid, {text})}
+                            maxLength={80}
+                            testID={`author-adder-${id}-${adder.xmlid}`}
+                        />
+                    );
+                }
+
+                if (adder.options.length === 0) {
+                    return null; // a flat yes/no adder — needs a switch, which is its own change
+                }
+
+                return (
+                    <SelectField
+                        key={adder.xmlid}
+                        label={adder.required ? adder.display : `${adder.display} (optional)`}
+                        value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
+                        options={adder.options.map((option) => option.display)}
+                        onChange={(display) => setAdder(adder.xmlid, {option: adder.options.find((option) => option.display === display)?.xmlid})}
+                        testID={`author-adder-${id}-${adder.xmlid}`}
+                    />
+                );
+            })}
+
+            {entry.modifiable ? <Modifiers id={id} edition={edition} power={trait as AuthoredPower} onChange={onChange} /> : null}
+        </View>
+    );
+}
+
+/**
+ * The defences a Resistant Protection is split across.
+ *
+ * Four numbers with no template behind them — see `FieldGroup`. The power's `levels` is derived
+ * from their sum at emit time, so there is nothing here for the player to keep in step.
+ */
+function DefenseFields({
+    id,
+    group,
+    trait,
+    onChange,
+}: {
+    id: string;
+    group: FieldGroup;
+    trait: AuthoredTrait;
+    onChange: (trait: AuthoredTrait) => void;
+}): React.JSX.Element {
+    const defense = (trait as AuthoredPower).defense ?? {pd: 0, ed: 0, mental: 0, power: 0};
+
+    return (
+        <View>
+            <Text variant="caption" muted>
+                {group.label}
+            </Text>
+            <View style={styles.grid}>
+                {group.fields.map((field) => (
+                    <View key={field.key} style={styles.gridCell}>
+                        <NumberField
+                            label={field.label}
+                            value={String(defense[field.key])}
+                            onChangeText={(text) =>
+                                onChange({...trait, defense: {...defense, [field.key]: Math.max(0, Number.parseInt(text, 10) || 0)}} as AuthoredTrait)
+                            }
+                            testID={`author-defense-${id}-${field.key}`}
+                        />
+                    </View>
+                ))}
+            </View>
+        </View>
+    );
+}
+
+/**
+ * A power's advantages and limitations.
+ *
+ * One list, not two, because which is which is the sign of what a modifier ends up costing rather
+ * than a property of the modifier — `ModifierCalculator` splits them on exactly that, and an
+ * option can flip a modifier from one to the other.
+ */
+function Modifiers({
+    id,
+    edition,
+    power,
+    onChange,
+}: {
+    id: string;
+    edition: AuthoringEdition;
+    power: AuthoredPower;
+    onChange: (trait: AuthoredTrait) => void;
+}): React.JSX.Element {
+    const available = useMemo(() => modifiers(edition), [edition]);
+    const byXmlid = useMemo(() => new Map(available.map((entry) => [entry.xmlid, entry])), [available]);
+
+    const add = (display: string): void => {
+        const entry = available.find((candidate) => candidate.display === display);
+
+        if (entry !== undefined) {
+            onChange({...power, modifiers: [...power.modifiers, {xmlid: entry.xmlid, adders: []}]} as AuthoredTrait);
+        }
+    };
+
+    const update = (index: number, revised: AuthoredModifier): void =>
+        onChange({...power, modifiers: power.modifiers.map((entry, position) => (position === index ? revised : entry))} as AuthoredTrait);
+
+    const remove = (index: number): void => onChange({...power, modifiers: power.modifiers.filter((_, position) => position !== index)} as AuthoredTrait);
+
+    return (
+        <View style={styles.modifiers}>
+            <Text variant="caption" muted>
+                Advantages &amp; limitations
+            </Text>
+
+            {power.modifiers.map((applied, index) => {
+                const entry = byXmlid.get(applied.xmlid);
+                const modifierId = `${id}-mod-${index}`;
+
+                return entry === undefined ? (
+                    <Text key={modifierId} testID={`author-modifier-unknown-${modifierId}`}>
+                        {edition} has no “{applied.xmlid}”.
+                    </Text>
+                ) : (
+                    <View key={modifierId} style={styles.complication}>
+                        <View style={styles.complicationHead}>
+                            <Text>{entry.display}</Text>
+                            <Button label="Remove" onPress={() => remove(index)} variant="secondary" testID={`author-remove-${modifierId}`} />
+                        </View>
+
+                        {entry.freeText ? (
+                            <TextField
+                                label={entry.display}
+                                value={applied.text ?? ''}
+                                onChangeText={(text) => update(index, {...applied, text})}
+                                maxLength={80}
+                                testID={`author-modifier-text-${modifierId}`}
+                            />
+                        ) : null}
+
+                        {entry.options.length === 0 ? null : (
+                            <SelectField
+                                label="Which"
+                                value={entry.options.find((option) => option.xmlid === applied.option)?.display ?? ''}
+                                options={entry.options.map((option) => option.display)}
+                                onChange={(display) => update(index, {...applied, option: entry.options.find((option) => option.display === display)?.xmlid})}
+                                testID={`author-modifier-option-${modifierId}`}
+                            />
+                        )}
+
+                        {entry.levels === null ? null : (
+                            <NumberField
+                                label={entry.levels.label}
+                                value={applied.levels === undefined ? '' : String(applied.levels)}
+                                onChangeText={(text) =>
+                                    update(index, {...applied, levels: text.trim() === '' ? 0 : Math.max(0, Number.parseInt(text, 10) || 0)})
+                                }
+                                testID={`author-modifier-levels-${modifierId}`}
+                            />
+                        )}
+
+                        {entry.adders.map((adder) => {
+                            const chosen = applied.adders.find((candidate) => candidate.xmlid === adder.xmlid);
+                            const setNested = (patch: {option?: string}): void =>
+                                update(index, {
+                                    ...applied,
+                                    adders:
+                                        chosen === undefined
+                                            ? [...applied.adders, {xmlid: adder.xmlid, ...patch}]
+                                            : applied.adders.map((candidate) => (candidate.xmlid === adder.xmlid ? {...candidate, ...patch} : candidate)),
+                                });
+
+                            return adder.options.length === 0 ? null : (
+                                <SelectField
+                                    key={adder.xmlid}
+                                    label={adder.display}
+                                    value={adder.options.find((option) => option.xmlid === chosen?.option)?.display ?? ''}
+                                    options={adder.options.map((option) => option.display)}
+                                    onChange={(display) => setNested({option: adder.options.find((option) => option.display === display)?.xmlid})}
+                                    testID={`author-modifier-adder-${modifierId}-${adder.xmlid}`}
+                                />
+                            );
+                        })}
+                    </View>
+                );
+            })}
+
+            <SelectField
+                label="Add advantage or limitation"
+                value=""
+                options={available.map((entry) => entry.display)}
+                onChange={add}
+                testID={`author-add-modifier-${id}`}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    content: {
+        padding: 16,
+        rowGap: 16,
+    },
+    fields: {
+        rowGap: 12,
+    },
+    grid: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        columnGap: 12,
+        rowGap: 12,
+        marginTop: 8,
+    },
+    gridCell: {
+        width: '30%',
+    },
+    complication: {
+        rowGap: 8,
+    },
+    complicationHead: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    modifiers: {
+        rowGap: 8,
+        marginTop: 4,
+    },
+    actions: {
+        flexDirection: 'row',
+        columnGap: 12,
+        justifyContent: 'flex-end',
+    },
+});

--- a/src/app/screens/CharacterDetailScreen.tsx
+++ b/src/app/screens/CharacterDetailScreen.tsx
@@ -35,6 +35,7 @@ import {
     type SheetCharacteristic,
     type SheetTrait,
 } from './characterSheet';
+import {parseSource, type AuthoredCharacter} from 'core/authoring';
 import {CharacterEditor, editableRecipe} from './CharacterEditor';
 import {PortraitFramer} from './PortraitFramer';
 import {CombatTracker} from './CombatTracker';
@@ -56,11 +57,16 @@ export interface CharacterDetailScreenProps {
      * screen (rather than pushing) so flipping between characters doesn't grow the back stack.
      */
     onSwitchCharacter?: (id: string) => void;
+    /**
+     * Re-open an authored character in the editor. Absent when authoring isn't reachable from
+     * wherever this screen is mounted (tests, and any future embed).
+     */
+    onEditAuthored?: (id: string, draft: AuthoredCharacter) => void;
 }
 
 const AVATAR = 96;
 
-export function CharacterDetailScreen({characterId, onReady, onRollRequest, onSwitchCharacter}: CharacterDetailScreenProps): React.JSX.Element {
+export function CharacterDetailScreen({characterId, onReady, onRollRequest, onSwitchCharacter, onEditAuthored}: CharacterDetailScreenProps): React.JSX.Element {
     const {characters: repository, statistics} = useRepositories();
     const roller = useDieRoller();
     const theme = useTheme();
@@ -94,6 +100,12 @@ export function CharacterDetailScreen({characterId, onReady, onRollRequest, onSw
     const character = state.status === 'ready' ? state.character : null;
     // Non-null only for a generated character whose recipe still resolves — see editableRecipe.
     const recipe = useMemo(() => (character === null ? null : editableRecipe(character)), [character]);
+    /**
+     * Non-null only for an authored character whose stored draft still parses. The two are mutually
+     * exclusive by construction: `origin` is one value, so a character is revised through its
+     * recipe or through its draft, never both.
+     */
+    const draft = useMemo(() => (character === null || character.origin !== 'authored' ? null : parseSource(character.source)), [character]);
     // "Only in Alternate Identity" form. Default on — matches legacy (which loaded
     // characters with showSecondary = true), so alt-ID stat boosts count by default.
     const [showSecondary, setShowSecondary] = useState(true);
@@ -241,6 +253,17 @@ export function CharacterDetailScreen({characterId, onReady, onRollRequest, onSw
                 </View>
 
                 {recipe !== null ? <CharacterEditor character={loaded} recipe={recipe} onRevised={load} /> : null}
+
+                {draft !== null && onEditAuthored !== undefined ? (
+                    <Card>
+                        <View style={styles.authored}>
+                            <Text variant="label" muted>
+                                AUTHORED CHARACTER
+                            </Text>
+                            <Button label="Edit" onPress={() => onEditAuthored(loaded.id, draft)} testID="edit-authored" />
+                        </View>
+                    </Card>
+                ) : null}
 
                 {sheet !== null ? (
                     <>
@@ -715,6 +738,11 @@ function Row({label, value}: {label: string; value: string}): React.JSX.Element 
 }
 
 const styles = StyleSheet.create({
+    authored: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
     centered: {
         alignItems: 'center',
         justifyContent: 'center',

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -442,3 +442,56 @@ describe('AuthorCharacterScreen — frameworks', () => {
         expect((powers[0].powers as Obj[]).map((slot) => slot.name)).toEqual(['Stun Gun', 'Net']);
     });
 });
+
+describe('AuthorCharacterScreen — martial arts and equipment', () => {
+    it('offers a section for each, drawing on the right catalogue', async () => {
+        const {tree} = await renderScreen();
+
+        expect(tree.root.findAllByProps({testID: 'author-add-martialArts'}).length).toBeGreaterThan(0);
+        // Equipment draws on the powers catalogue — an item is a power in a different bucket.
+        expect(tree.root.findAllByProps({testID: 'author-add-equipment'}).length).toBeGreaterThan(0);
+    });
+
+    it('counts a maneuver and an item toward the same total', async () => {
+        const {tree} = await renderScreen({
+            initial: {
+                ...emptyDraft('6E'),
+                name: 'Fighter',
+                martialArts: [{xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0}],
+                equipment: [{xmlid: 'FORCEFIELD', name: 'Vest', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 4, ed: 4, mental: 0, power: 0}}],
+            },
+        });
+
+        // Basic Strike 3 + Vest 12.
+        expect(textOf(tree, 'author-spend')).toBe('15 spent of 400');
+    });
+
+    it("warns that a defensive item will not add to the character's totals", async () => {
+        const {tree} = await renderScreen({
+            initial: {
+                ...emptyDraft('6E'),
+                name: 'Armoured',
+                equipment: [{xmlid: 'FORCEFIELD', name: 'Vest', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 4, ed: 4, mental: 0, power: 0}}],
+            },
+        });
+
+        const warnings = tree.root.findAllByProps({testID: 'author-problem-warning-0'});
+        expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    it('saves and re-opens both', async () => {
+        const full: AuthoredCharacter = {
+            ...emptyDraft('6E'),
+            name: 'Complete',
+            martialArts: [{xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0}],
+            equipment: [{xmlid: 'FORCEFIELD', name: 'Vest', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 4, ed: 4, mental: 0, power: 0}}],
+        };
+        const {tree, saved} = await renderScreen({initial: full});
+
+        await press(tree, 'author-save');
+
+        expect(saved).toHaveLength(1);
+        expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(full);
+        expect(saved[0].document).toEqual(build(full));
+    });
+});

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -304,3 +304,75 @@ describe('AuthorCharacterScreen — one renderer for four categories', () => {
         expect(saved[0].document).toEqual(build(full));
     });
 });
+
+describe('AuthorCharacterScreen — powers and their modifiers', () => {
+    const grenade: AuthoredCharacter = {
+        ...emptyDraft('6E'),
+        name: 'Bomber',
+        powers: [
+            {
+                xmlid: 'ENERGYBLAST',
+                name: 'Grenade',
+                input: 'ED',
+                adders: [],
+                levels: 10,
+                modifiers: [
+                    {xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: []},
+                    {xmlid: 'FOCUS', option: 'OAF', adders: []},
+                ],
+            },
+        ],
+    };
+
+    it('shows the real cost, which is what the character actually pays', async () => {
+        const {tree} = await renderScreen({initial: grenade});
+
+        // (50 x 1.5) / 2 = 37. The meter reads real cost, not active — active is what the power
+        // is worth, real is what it costs.
+        expect(textOf(tree, 'author-spend')).toBe('37 spent of 400');
+    });
+
+    it('offers a modifier list on a power and not on a skill', async () => {
+        const {tree} = await renderScreen({
+            initial: {
+                ...emptyDraft('6E'),
+                powers: [{xmlid: 'ENERGYBLAST', name: 'Bolt', input: '', adders: [], levels: 5, modifiers: []}],
+                skills: [{xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 0}],
+            },
+        });
+
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-powers-0'}).length).toBeGreaterThan(0);
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-skills-0'})).toHaveLength(0);
+    });
+
+    it('draws the defence fields for Resistant Protection, and blocks a save without them', async () => {
+        const {tree, saved} = await renderScreen({
+            initial: {...emptyDraft('6E'), name: 'Bare', powers: [{xmlid: 'FORCEFIELD', name: 'Skin', input: '', adders: [], levels: 0, modifiers: []}]},
+        });
+
+        for (const field of ['pd', 'ed', 'mental', 'power']) {
+            expect(tree.root.findAllByProps({testID: `author-defense-powers-0-${field}`}).length).toBeGreaterThan(0);
+        }
+
+        expect(textOf(tree, 'author-problem-error-0')).toContain('grants no defence');
+        await press(tree, 'author-save');
+        expect(saved).toHaveLength(0);
+    });
+
+    it('saves and re-opens a power with modifiers and defences intact', async () => {
+        const full: AuthoredCharacter = {
+            ...grenade,
+            powers: [
+                ...grenade.powers,
+                {xmlid: 'FORCEFIELD', name: 'Dense Body', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 17, ed: 17, mental: 0, power: 0}},
+            ],
+        };
+        const {tree, saved} = await renderScreen({initial: full});
+
+        await press(tree, 'author-save');
+
+        expect(saved).toHaveLength(1);
+        expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(full);
+        expect(saved[0].document).toEqual(build(full));
+    });
+});

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -22,7 +22,7 @@
 import React from 'react';
 import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
 import type {CharacterRepository, SaveCharacter} from 'core/ports';
-import {parseSource, build, emit, emptyDraft, type AuthoredCharacter} from 'core/authoring';
+import {parseSource, build, declaredFor, emit, emptyDraft, type AuthoredCharacter} from 'core/authoring';
 import type {Repositories} from 'infra/persistence/repositories';
 import {AuthoringDraftProvider, type TraitAddress} from 'app/providers/AuthoringDraftProvider';
 import {AuthoringProvider} from 'app/providers/AuthoringProvider';
@@ -193,7 +193,7 @@ describe('AuthorCharacterScreen — saving', () => {
 
         expect(reopened).toEqual(draft);
         expect(emit(reopened)).toEqual(emit(draft));
-        expect(saved[0].document).toEqual(build(draft));
+        expect(saved[0].document).toEqual({...build(draft), basicConfiguration: declaredFor(draft.budget)});
     });
 
     it('keeps the id when editing, rather than making a second character', async () => {
@@ -324,7 +324,7 @@ describe('AuthorCharacterScreen — one renderer for four categories', () => {
 
         expect(saved).toHaveLength(1);
         expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(full);
-        expect(saved[0].document).toEqual(build(full));
+        expect(saved[0].document).toEqual({...build(full), basicConfiguration: declaredFor(full.budget)});
     });
 });
 
@@ -396,7 +396,7 @@ describe('AuthorCharacterScreen — powers and their modifiers', () => {
 
         expect(saved).toHaveLength(1);
         expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(full);
-        expect(saved[0].document).toEqual(build(full));
+        expect(saved[0].document).toEqual({...build(full), basicConfiguration: declaredFor(full.budget)});
     });
 });
 
@@ -518,6 +518,106 @@ describe('AuthorCharacterScreen — martial arts and equipment', () => {
 
         expect(saved).toHaveLength(1);
         expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(full);
-        expect(saved[0].document).toEqual(build(full));
+        expect(saved[0].document).toEqual({...build(full), basicConfiguration: declaredFor(full.budget)});
+    });
+});
+
+describe('AuthorCharacterScreen — the campaign allowance', () => {
+    /** A field's current value, which lives on the input rather than as rendered text. */
+    const valueOf = (tree: ReactTestRenderer, testID: string): string =>
+        tree.root.findAllByProps({testID}).find((node) => typeof node.props.onChangeText === 'function')?.props.value ?? '';
+
+    const pick = async (tree: ReactTestRenderer, testID: string, option: string): Promise<void> => {
+        await act(async () => {
+            tree.root
+                .findAllByProps({testID})
+                .find((node) => typeof node.props.onPress === 'function')
+                ?.props.onPress();
+        });
+        await act(async () => {
+            tree.root
+                .findAllByProps({testID: `${testID}-option-${option}`})
+                .find((node) => typeof node.props.onPress === 'function')
+                ?.props.onPress();
+        });
+        await act(async () => {});
+    };
+
+    it('starts a 6E character at Standard, and totals against it', async () => {
+        const {tree} = await renderScreen({initial: {...emptyDraft('6E'), characteristics: {str: 20}}});
+
+        expect(textOf(tree, 'author-spend')).toBe('10 spent of 400');
+        expect(valueOf(tree, 'author-budget-base')).toBe('400');
+        expect(valueOf(tree, 'author-budget-limit')).toBe('75');
+    });
+
+    it('changes the total when a different level is picked', async () => {
+        const {tree} = await renderScreen({initial: {...emptyDraft('6E'), characteristics: {str: 20}}});
+
+        await pick(tree, 'author-power-level', '6E Low-Powered');
+
+        // 6E Low-Powered is a 300-point character. Nothing about the build changed, only what it
+        // is allowed to cost.
+        expect(textOf(tree, 'author-spend')).toBe('10 spent of 300');
+    });
+
+    it('accepts an allowance the rulebooks have no name for', async () => {
+        const {tree} = await renderScreen({initial: emptyDraft('6E')});
+
+        await type(tree, 'author-budget-base', '525');
+
+        expect(textOf(tree, 'author-spend')).toBe('0 spent of 525');
+    });
+
+    it('labels the two editions in the units each is quoted in', async () => {
+        const sixth = await renderScreen({initial: emptyDraft('6E')});
+        const fifth = await renderScreen({initial: emptyDraft('5E')});
+
+        // 6E quotes the whole allowance; 5E quotes a base that disadvantages then add to.
+        const label = (tree: ReactTestRenderer): string =>
+            tree.root.findAllByProps({testID: 'author-budget-base'}).find((node) => node.props.label !== undefined)?.props.label ?? '';
+
+        expect(label(sixth.tree)).toBe('Total points');
+        expect(label(fifth.tree)).toBe('Base points');
+    });
+
+    it('lets 5E disadvantages raise the total, and 6E complications not', async () => {
+        const psych = [
+            {
+                xmlid: 'PSYCHOLOGICALLIMITATION',
+                input: 'Code Of The Hero',
+                adders: [
+                    {xmlid: 'SITUATION', option: 'COMMON'},
+                    {xmlid: 'INTENSITY', option: 'STRONG'},
+                ],
+            },
+        ];
+        const sixth = await renderScreen({initial: {...emptyDraft('6E'), complications: psych}});
+        const fifth = await renderScreen({initial: {...emptyDraft('5E'), complications: psych}});
+
+        // 6E: still 400. 5E: 200 base + the 15 the complication is worth.
+        expect(textOf(sixth.tree, 'author-spend')).toBe('0 spent of 400');
+        expect(textOf(fifth.tree, 'author-spend')).toBe('0 spent of 215');
+    });
+
+    it('saves the allowance so the character declares what it was built on', async () => {
+        const {tree, saved} = await renderScreen({initial: {...emptyDraft('6E'), name: 'Declared', characteristics: {str: 20}}});
+
+        await type(tree, 'author-budget-base', '350');
+        await press(tree, 'author-save');
+
+        // Without this the sheet's nameplate shows neither points nor campaign tier.
+        expect((saved[0].document as Obj).basicConfiguration).toEqual({basePoints: 350, disadPoints: 75, experience: 0});
+        expect((saved[0].source as Obj).budget).toEqual({base: 350, complicationLimit: 75});
+    });
+
+    it('re-opens at the allowance it was saved with', async () => {
+        const custom: AuthoredCharacter = {...emptyDraft('6E'), name: 'Custom', budget: {base: 525, complicationLimit: 90}};
+        const {tree, saved} = await renderScreen({initial: custom});
+
+        await press(tree, 'author-save');
+
+        expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(custom);
+        expect(textOf(tree, 'author-spend')).toBe('0 spent of 525');
     });
 });

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -136,13 +136,15 @@ describe('AuthorCharacterScreen', () => {
         expect(textOf(tree, 'author-spend')).toBe(`${spent} spent of 400`);
     });
 
-    it('reports going over budget rather than preventing it', async () => {
+    it('calls what is spent past the allowance experience, not an overspend', async () => {
         const {tree} = await renderScreen();
 
+        // 6E STR is 1/point over a base of 10, so STR 500 is 490 — 90 past a 400-point allowance.
         await type(tree, 'author-char-str', '500');
 
-        expect(textOf(tree, 'author-remaining')).toContain('over budget');
-        // Still saveable: over budget is a GM's problem, not a malformed character.
+        expect(textOf(tree, 'author-remaining')).toBe('90 experience');
+        // And it saves: a character who costs more than their starting points has earned the
+        // difference, which is a fact about them rather than a fault.
         expect(tree.root.findAllByProps({testID: 'author-save'}).some((node) => node.props.disabled === false)).toBe(true);
     });
 
@@ -598,6 +600,23 @@ describe('AuthorCharacterScreen — the campaign allowance', () => {
         // 6E: still 400. 5E: 200 base + the 15 the complication is worth.
         expect(textOf(sixth.tree, 'author-spend')).toBe('0 spent of 400');
         expect(textOf(fifth.tree, 'author-spend')).toBe('0 spent of 215');
+    });
+
+    it('declares the experience, so the nameplate reads "base + earned"', async () => {
+        const {tree, saved} = await renderScreen({initial: {...emptyDraft('6E'), name: 'Veteran', characteristics: {str: 500}}});
+
+        await press(tree, 'author-save');
+
+        // `formatPoints` on the sheet turns exactly this into "400 + 90 pts".
+        expect((saved[0].document as Obj).basicConfiguration).toEqual({basePoints: 400, disadPoints: 75, experience: 90});
+    });
+
+    it('declares no experience for a character inside its allowance', async () => {
+        const {tree, saved} = await renderScreen({initial: {...emptyDraft('6E'), name: 'Fresh', characteristics: {str: 20}}});
+
+        await press(tree, 'author-save');
+
+        expect((saved[0].document as Obj).basicConfiguration).toEqual({basePoints: 400, disadPoints: 75, experience: 0});
     });
 
     it('saves the allowance so the character declares what it was built on', async () => {

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -1,0 +1,236 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Authoring a character, end to end through the screen.
+ *
+ * What is worth testing here is not that fields render — it is the three claims the feature rests
+ * on: the points meter is the engine's own answer, a draft that saves can be re-opened and rebuilds
+ * the same character, and an unbuildable draft cannot be saved.
+ */
+import React from 'react';
+import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
+import type {CharacterRepository, SaveCharacter} from 'core/ports';
+import {parseSource, build, emit, type AuthoredCharacter} from 'core/authoring';
+import type {Repositories} from 'infra/persistence/repositories';
+import {AuthoringProvider} from 'app/providers/AuthoringProvider';
+import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
+import {ThemeProvider} from 'app/theme';
+import {AuthorCharacterScreen} from '../AuthorCharacterScreen';
+
+type Obj = Record<string, any>;
+
+const renderScreen = async (
+    props: Partial<React.ComponentProps<typeof AuthorCharacterScreen>> = {},
+    existing: string[] = [],
+): Promise<{tree: ReactTestRenderer; saved: SaveCharacter[]; savedIds: string[]}> => {
+    const saved: SaveCharacter[] = [];
+    const savedIds: string[] = [];
+    const characters = {
+        save: async (input: SaveCharacter) => {
+            saved.push(input);
+        },
+        list: async () => existing.map((id) => ({id})),
+    } as unknown as CharacterRepository;
+
+    let tree!: ReactTestRenderer;
+    await act(async () => {
+        tree = TestRenderer.create(
+            <ThemeProvider colorScheme="dark">
+                <RepositoriesProvider repositories={{characters} as unknown as Repositories}>
+                    <AuthoringProvider>
+                        <AuthorCharacterScreen onSaved={(id) => savedIds.push(id)} onCancel={() => {}} {...props} />
+                    </AuthoringProvider>
+                </RepositoriesProvider>
+            </ThemeProvider>,
+        );
+    });
+    await act(async () => {});
+
+    return {tree, saved, savedIds};
+};
+
+const type = async (tree: ReactTestRenderer, testID: string, value: string): Promise<void> => {
+    await act(async () => {
+        tree.root
+            .findAllByProps({testID})
+            .find((node) => typeof node.props.onChangeText === 'function')
+            ?.props.onChangeText(value);
+    });
+};
+
+const press = async (tree: ReactTestRenderer, testID: string): Promise<void> => {
+    await act(async () => {
+        tree.root
+            .findAllByProps({testID})
+            .find((node) => typeof node.props.onPress === 'function')
+            ?.props.onPress();
+    });
+    await act(async () => {});
+};
+
+const textOf = (tree: ReactTestRenderer, testID: string): string => {
+    const node = tree.root.findAllByProps({testID}).find((candidate) => candidate.props.children !== undefined);
+    const flatten = (children: unknown): string =>
+        Array.isArray(children) ? children.map(flatten).join('') : children === null || children === undefined || typeof children === 'boolean' ? '' : String(children);
+
+    return node === undefined ? '' : flatten(node.props.children);
+};
+
+describe('AuthorCharacterScreen', () => {
+    it("shows the engine's own points total as characteristics change", async () => {
+        const {tree} = await renderScreen();
+
+        // 6E STR is 1 point per point over a base of 10, DEX is 2 per point over 10.
+        await type(tree, 'author-char-str', '20');
+        expect(textOf(tree, 'author-spend')).toBe('10 spent of 400');
+
+        await type(tree, 'author-char-dex', '18');
+        expect(textOf(tree, 'author-spend')).toBe('26 spent of 400');
+        expect(textOf(tree, 'author-remaining')).toBe('374 remaining');
+    });
+
+    it('agrees exactly with what core prices, because it asks the same engine', async () => {
+        const {tree} = await renderScreen();
+
+        await type(tree, 'author-char-str', '30');
+        await type(tree, 'author-char-con', '25');
+
+        const reference = build({edition: '6E', name: '', player: '', characteristics: {str: 30, con: 25}, complications: []});
+        const spent = (reference.characteristics as Obj[]).reduce((total, entry) => total + Number(entry.cost), 0);
+
+        expect(textOf(tree, 'author-spend')).toBe(`${spent} spent of 400`);
+    });
+
+    it('reports going over budget rather than preventing it', async () => {
+        const {tree} = await renderScreen();
+
+        await type(tree, 'author-char-str', '500');
+
+        expect(textOf(tree, 'author-remaining')).toContain('over budget');
+        // Still saveable: over budget is a GM's problem, not a malformed character.
+        expect(tree.root.findAllByProps({testID: 'author-save'}).some((node) => node.props.disabled === false)).toBe(true);
+    });
+
+    it('says complications fund a 5E build and not a 6E one', async () => {
+        const sixth = await renderScreen();
+        expect(textOf(sixth.tree, 'author-complications-total')).toContain('grant no points');
+
+        const fifth = await renderScreen({initial: {edition: '5E', name: 'Fifth', player: '', characteristics: {}, complications: []}});
+        expect(textOf(fifth.tree, 'author-complications-total')).toContain('fund the build');
+    });
+});
+
+describe('AuthorCharacterScreen — saving', () => {
+    const draft: AuthoredCharacter = {
+        edition: '6E',
+        name: 'Testable',
+        player: 'Phil',
+        characteristics: {str: 20, dex: 18},
+        complications: [
+            {
+                xmlid: 'PSYCHOLOGICALLIMITATION',
+                input: 'Code Of The Hero',
+                adders: [
+                    {xmlid: 'SITUATION', option: 'COMMON'},
+                    {xmlid: 'INTENSITY', option: 'STRONG'},
+                ],
+            },
+        ],
+    };
+
+    it('saves the document, the draft, and marks it authored', async () => {
+        const {tree, saved, savedIds} = await renderScreen({initial: draft});
+
+        await press(tree, 'author-save');
+
+        expect(saved).toHaveLength(1);
+        expect(saved[0]).toMatchObject({name: 'Testable', player: 'Phil', edition: '6E', origin: 'authored'});
+        expect(saved[0].source).toBeDefined();
+        expect(savedIds).toEqual(['authored-testable']);
+    });
+
+    it('re-opens the saved draft and rebuilds the identical character', async () => {
+        const {tree, saved} = await renderScreen({initial: draft});
+        await press(tree, 'author-save');
+
+        // The round trip that makes an authored character editable at all.
+        const reopened = parseSource(JSON.parse(JSON.stringify(saved[0].source)))!;
+
+        expect(reopened).toEqual(draft);
+        expect(emit(reopened)).toEqual(emit(draft));
+        expect(saved[0].document).toEqual(build(draft));
+    });
+
+    it('keeps the id when editing, rather than making a second character', async () => {
+        const {tree, saved, savedIds} = await renderScreen({initial: draft, characterId: 'authored-testable'});
+
+        await press(tree, 'author-save');
+
+        expect(saved[0].id).toBe('authored-testable');
+        expect(savedIds).toEqual(['authored-testable']);
+    });
+
+    it('suffixes the id rather than overwriting a character with the same name', async () => {
+        const {tree, saved} = await renderScreen({initial: draft}, ['authored-testable']);
+
+        await press(tree, 'author-save');
+
+        expect(saved[0].id).toBe('authored-testable-2');
+    });
+
+    it('locks the edition once saved, because re-pricing under the other rulebook is a new character', async () => {
+        const {tree} = await renderScreen({initial: draft, characterId: 'authored-testable'});
+
+        expect(textOf(tree, 'author-edition-locked')).toBe('6th Edition');
+        expect(tree.root.findAllByProps({testID: 'segment-5E'})).toHaveLength(0);
+    });
+});
+
+describe('AuthorCharacterScreen — refusing to save what the engine cannot price', () => {
+    it('blocks a complication missing its required adders, and says which', async () => {
+        const {tree, saved} = await renderScreen({
+            initial: {edition: '6E', name: 'Broken', player: '', characteristics: {}, complications: [{xmlid: 'PSYCHOLOGICALLIMITATION', input: 'Code', adders: []}]},
+        });
+
+        expect(textOf(tree, 'author-problem-error-0')).toContain('Situation');
+        expect(tree.root.findAllByProps({testID: 'author-save'}).every((node) => node.props.disabled !== false)).toBe(true);
+
+        await press(tree, 'author-save');
+        expect(saved).toHaveLength(0);
+    });
+
+    it('blocks a complication this edition does not define — the silent-zero trap', async () => {
+        const {tree, saved} = await renderScreen({
+            initial: {edition: '6E', name: 'Broken', player: '', characteristics: {}, complications: [{xmlid: 'NOT_REAL', input: '', adders: []}]},
+        });
+
+        expect(textOf(tree, 'author-problem-error-0')).toContain('has no complication');
+        // And it does not try to price it while broken, which is what the meter says instead.
+        expect(textOf(tree, 'author-spend')).toContain('unavailable');
+
+        await press(tree, 'author-save');
+        expect(saved).toHaveLength(0);
+    });
+
+    it('warns without blocking when a character has no name', async () => {
+        const {tree, saved} = await renderScreen({initial: {edition: '6E', name: '', player: '', characteristics: {str: 20}, complications: []}});
+
+        expect(tree.root.findAllByProps({testID: 'author-problem-warning-0'}).length).toBeGreaterThan(0);
+
+        await press(tree, 'author-save');
+        expect(saved).toHaveLength(1);
+        expect(saved[0].name).toBe('Unnamed');
+    });
+});

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -376,3 +376,69 @@ describe('AuthorCharacterScreen — powers and their modifiers', () => {
         expect(saved[0].document).toEqual(build(full));
     });
 });
+
+describe('AuthorCharacterScreen — frameworks', () => {
+    const gadgets: AuthoredCharacter = {
+        ...emptyDraft('6E'),
+        name: 'Gadgeteer',
+        frameworks: [
+            {
+                kind: 'multipower',
+                name: 'Utility Belt',
+                reserve: 60,
+                modifiers: [],
+                slots: [
+                    {xmlid: 'ENERGYBLAST', name: 'Stun Gun', input: 'ED', adders: [], levels: 12, modifiers: []},
+                    {xmlid: 'ENERGYBLAST', name: 'Net', input: 'ED', adders: [], levels: 10, modifiers: []},
+                ],
+            },
+        ],
+    };
+
+    it('totals the reserve and every slot', async () => {
+        const {tree} = await renderScreen({initial: gadgets});
+
+        // 60 reserve + 60/10 + 50/10 = 71.
+        expect(textOf(tree, 'author-spend')).toBe('71 spent of 400');
+    });
+
+    it('edits a slot with the same row a standalone power uses', async () => {
+        const {tree} = await renderScreen({initial: gadgets});
+
+        // Slots are powers: they get a name, and a modifier list of their own.
+        expect(tree.root.findAllByProps({testID: 'author-name-framework-0-slot-0'}).length).toBeGreaterThan(0);
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-framework-0-slot-0'}).length).toBeGreaterThan(0);
+    });
+
+    it('says slots are fixed slots rather than silently making them so', async () => {
+        const {tree} = await renderScreen();
+        const add = tree.root.findAllByProps({testID: 'author-add-framework'}).find((node) => node.props.hint !== undefined);
+
+        // The variable kind's divisor is unreachable in the engine (H13), so it is not offered.
+        expect(add?.props.hint).toBe('Slots are fixed slots');
+    });
+
+    it('blocks a framework with no reserve', async () => {
+        const {tree, saved} = await renderScreen({
+            initial: {...emptyDraft('6E'), name: 'Broken', frameworks: [{kind: 'multipower', name: 'Empty', reserve: 0, modifiers: [], slots: []}]},
+        });
+
+        expect(textOf(tree, 'author-problem-error-0')).toContain('reserve of at least 1');
+        await press(tree, 'author-save');
+        expect(saved).toHaveLength(0);
+    });
+
+    it('saves and re-opens a framework with its slots nested', async () => {
+        const {tree, saved} = await renderScreen({initial: gadgets});
+
+        await press(tree, 'author-save');
+
+        expect(saved).toHaveLength(1);
+        expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(gadgets);
+
+        // And the document the sheet will read has the slots inside the container, not beside it.
+        const powers = (saved[0].document as Obj).powers as Obj[];
+        expect(powers).toHaveLength(1);
+        expect((powers[0].powers as Obj[]).map((slot) => slot.name)).toEqual(['Stun Gun', 'Net']);
+    });
+});

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -22,7 +22,7 @@
 import React from 'react';
 import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
 import type {CharacterRepository, SaveCharacter} from 'core/ports';
-import {parseSource, build, emit, type AuthoredCharacter} from 'core/authoring';
+import {parseSource, build, emit, emptyDraft, type AuthoredCharacter} from 'core/authoring';
 import type {Repositories} from 'infra/persistence/repositories';
 import {AuthoringProvider} from 'app/providers/AuthoringProvider';
 import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
@@ -107,7 +107,7 @@ describe('AuthorCharacterScreen', () => {
         await type(tree, 'author-char-str', '30');
         await type(tree, 'author-char-con', '25');
 
-        const reference = build({edition: '6E', name: '', player: '', characteristics: {str: 30, con: 25}, complications: []});
+        const reference = build({...emptyDraft('6E'), characteristics: {str: 30, con: 25}});
         const spent = (reference.characteristics as Obj[]).reduce((total, entry) => total + Number(entry.cost), 0);
 
         expect(textOf(tree, 'author-spend')).toBe(`${spent} spent of 400`);
@@ -127,14 +127,14 @@ describe('AuthorCharacterScreen', () => {
         const sixth = await renderScreen();
         expect(textOf(sixth.tree, 'author-complications-total')).toContain('grant no points');
 
-        const fifth = await renderScreen({initial: {edition: '5E', name: 'Fifth', player: '', characteristics: {}, complications: []}});
+        const fifth = await renderScreen({initial: {...emptyDraft('5E'), name: 'Fifth'}});
         expect(textOf(fifth.tree, 'author-complications-total')).toContain('fund the build');
     });
 });
 
 describe('AuthorCharacterScreen — saving', () => {
     const draft: AuthoredCharacter = {
-        edition: '6E',
+        ...emptyDraft('6E'),
         name: 'Testable',
         player: 'Phil',
         characteristics: {str: 20, dex: 18},
@@ -201,7 +201,7 @@ describe('AuthorCharacterScreen — saving', () => {
 describe('AuthorCharacterScreen — refusing to save what the engine cannot price', () => {
     it('blocks a complication missing its required adders, and says which', async () => {
         const {tree, saved} = await renderScreen({
-            initial: {edition: '6E', name: 'Broken', player: '', characteristics: {}, complications: [{xmlid: 'PSYCHOLOGICALLIMITATION', input: 'Code', adders: []}]},
+            initial: {...emptyDraft('6E'), name: 'Broken', complications: [{xmlid: 'PSYCHOLOGICALLIMITATION', input: 'Code', adders: []}]},
         });
 
         expect(textOf(tree, 'author-problem-error-0')).toContain('Situation');
@@ -213,7 +213,7 @@ describe('AuthorCharacterScreen — refusing to save what the engine cannot pric
 
     it('blocks a complication this edition does not define — the silent-zero trap', async () => {
         const {tree, saved} = await renderScreen({
-            initial: {edition: '6E', name: 'Broken', player: '', characteristics: {}, complications: [{xmlid: 'NOT_REAL', input: '', adders: []}]},
+            initial: {...emptyDraft('6E'), name: 'Broken', complications: [{xmlid: 'NOT_REAL', input: '', adders: []}]},
         });
 
         expect(textOf(tree, 'author-problem-error-0')).toContain('has no complication');
@@ -225,12 +225,82 @@ describe('AuthorCharacterScreen — refusing to save what the engine cannot pric
     });
 
     it('warns without blocking when a character has no name', async () => {
-        const {tree, saved} = await renderScreen({initial: {edition: '6E', name: '', player: '', characteristics: {str: 20}, complications: []}});
+        const {tree, saved} = await renderScreen({initial: {...emptyDraft('6E'), characteristics: {str: 20}}});
 
         expect(tree.root.findAllByProps({testID: 'author-problem-warning-0'}).length).toBeGreaterThan(0);
 
         await press(tree, 'author-save');
         expect(saved).toHaveLength(1);
         expect(saved[0].name).toBe('Unnamed');
+    });
+});
+
+describe('AuthorCharacterScreen — one renderer for four categories', () => {
+    it('offers a section per category, each populated from its own catalogue', async () => {
+        const {tree} = await renderScreen();
+
+        for (const key of ['skills', 'perks', 'talents', 'complications']) {
+            expect(tree.root.findAllByProps({testID: `author-add-${key}`}).length).toBeGreaterThan(0);
+        }
+    });
+
+    it('says how many entries need a form of their own rather than quietly shortening the list', async () => {
+        const {tree} = await renderScreen();
+        const add = tree.root.findAllByProps({testID: 'author-add-skills'}).find((node) => node.props.hint !== undefined);
+
+        // A shorter list reads as "the app lacks Weapon Familiarity"; this reads as "not yet".
+        expect(add?.props.hint).toMatch(/\d+ more need a form of their own/);
+    });
+
+    it('prices a skill through the same engine the meter uses', async () => {
+        const skill: AuthoredCharacter = {
+            ...emptyDraft('6E'),
+            name: 'Tumbler',
+            characteristics: {dex: 18},
+            skills: [{xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 2}],
+        };
+        const {tree} = await renderScreen({initial: skill});
+
+        // DEX 18 is 16 points; Acrobatics +2 is 3 + 2*2 = 7.
+        expect(textOf(tree, 'author-spend')).toBe('23 spent of 400');
+    });
+
+    it('blocks a skill with no characteristic chosen, which would price at 0', async () => {
+        const {tree, saved} = await renderScreen({
+            initial: {...emptyDraft('6E'), name: 'Broken', skills: [{xmlid: 'ACROBATICS', input: '', adders: [], levels: 0}]},
+        });
+
+        expect(textOf(tree, 'author-problem-error-0')).toContain('which characteristic');
+
+        await press(tree, 'author-save');
+        expect(saved).toHaveLength(0);
+    });
+
+    it('saves and re-opens a character with all four categories filled', async () => {
+        const full: AuthoredCharacter = {
+            ...emptyDraft('6E'),
+            name: 'Complete',
+            characteristics: {dex: 18},
+            skills: [{xmlid: 'LANGUAGES', input: 'French', adders: [], option: 'FLUENT', levels: 0}],
+            perks: [{xmlid: 'ANONYMITY', input: '', adders: [], levels: 0}],
+            talents: [{xmlid: 'COMBAT_LUCK', input: '', adders: [], levels: 2}],
+            complications: [
+                {
+                    xmlid: 'PSYCHOLOGICALLIMITATION',
+                    input: 'Code Of The Hero',
+                    adders: [
+                        {xmlid: 'SITUATION', option: 'COMMON'},
+                        {xmlid: 'INTENSITY', option: 'STRONG'},
+                    ],
+                },
+            ],
+        };
+        const {tree, saved} = await renderScreen({initial: full});
+
+        await press(tree, 'author-save');
+
+        expect(saved).toHaveLength(1);
+        expect(parseSource(JSON.parse(JSON.stringify(saved[0].source)))).toEqual(full);
+        expect(saved[0].document).toEqual(build(full));
     });
 });

--- a/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorCharacterScreen.test.tsx
@@ -24,6 +24,7 @@ import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
 import type {CharacterRepository, SaveCharacter} from 'core/ports';
 import {parseSource, build, emit, emptyDraft, type AuthoredCharacter} from 'core/authoring';
 import type {Repositories} from 'infra/persistence/repositories';
+import {AuthoringDraftProvider, type TraitAddress} from 'app/providers/AuthoringDraftProvider';
 import {AuthoringProvider} from 'app/providers/AuthoringProvider';
 import {RepositoriesProvider} from 'app/providers/RepositoriesProvider';
 import {ThemeProvider} from 'app/theme';
@@ -34,9 +35,10 @@ type Obj = Record<string, any>;
 const renderScreen = async (
     props: Partial<React.ComponentProps<typeof AuthorCharacterScreen>> = {},
     existing: string[] = [],
-): Promise<{tree: ReactTestRenderer; saved: SaveCharacter[]; savedIds: string[]}> => {
+): Promise<{tree: ReactTestRenderer; saved: SaveCharacter[]; savedIds: string[]; edits: Array<{address: TraitAddress; category: string}>}> => {
     const saved: SaveCharacter[] = [];
     const savedIds: string[] = [];
+    const edits: Array<{address: TraitAddress; category: string}> = [];
     const characters = {
         save: async (input: SaveCharacter) => {
             saved.push(input);
@@ -50,7 +52,14 @@ const renderScreen = async (
             <ThemeProvider colorScheme="dark">
                 <RepositoriesProvider repositories={{characters} as unknown as Repositories}>
                     <AuthoringProvider>
-                        <AuthorCharacterScreen onSaved={(id) => savedIds.push(id)} onCancel={() => {}} {...props} />
+                        <AuthoringDraftProvider>
+                            <AuthorCharacterScreen
+                                onSaved={(id) => savedIds.push(id)}
+                                onCancel={() => {}}
+                                onEditTrait={(address, category) => edits.push({address, category})}
+                                {...props}
+                            />
+                        </AuthoringDraftProvider>
                     </AuthoringProvider>
                 </RepositoriesProvider>
             </ThemeProvider>,
@@ -58,7 +67,7 @@ const renderScreen = async (
     });
     await act(async () => {});
 
-    return {tree, saved, savedIds};
+    return {tree, saved, savedIds, edits};
 };
 
 const type = async (tree: ReactTestRenderer, testID: string, value: string): Promise<void> => {
@@ -80,12 +89,26 @@ const press = async (tree: ReactTestRenderer, testID: string): Promise<void> => 
     await act(async () => {});
 };
 
+/**
+ * All the text rendered under a testID, however deeply.
+ *
+ * Walks the rendered instances rather than reading `props.children`, because a row's children are
+ * `<Text>` elements rather than strings — flattening the props alone yields "[object Object]".
+ */
 const textOf = (tree: ReactTestRenderer, testID: string): string => {
-    const node = tree.root.findAllByProps({testID}).find((candidate) => candidate.props.children !== undefined);
-    const flatten = (children: unknown): string =>
-        Array.isArray(children) ? children.map(flatten).join('') : children === null || children === undefined || typeof children === 'boolean' ? '' : String(children);
+    const collect = (node: unknown): string => {
+        if (typeof node === 'string' || typeof node === 'number') {
+            return String(node);
+        }
 
-    return node === undefined ? '' : flatten(node.props.children);
+        const children = (node as {children?: unknown[]} | null)?.children;
+
+        return Array.isArray(children) ? children.map(collect).join('') : '';
+    };
+
+    const [node] = tree.root.findAllByProps({testID});
+
+    return node === undefined ? '' : collect(node);
 };
 
 describe('AuthorCharacterScreen', () => {
@@ -332,27 +355,27 @@ describe('AuthorCharacterScreen — powers and their modifiers', () => {
         expect(textOf(tree, 'author-spend')).toBe('37 spent of 400');
     });
 
-    it('offers a modifier list on a power and not on a skill', async () => {
-        const {tree} = await renderScreen({
-            initial: {
-                ...emptyDraft('6E'),
-                powers: [{xmlid: 'ENERGYBLAST', name: 'Bolt', input: '', adders: [], levels: 5, modifiers: []}],
-                skills: [{xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 0}],
-            },
-        });
+    it('shows a power as one row with its cost, not a form', async () => {
+        const {tree} = await renderScreen({initial: grenade});
 
-        expect(tree.root.findAllByProps({testID: 'author-add-modifier-powers-0'}).length).toBeGreaterThan(0);
-        expect(tree.root.findAllByProps({testID: 'author-add-modifier-skills-0'})).toHaveLength(0);
+        // The form is a screen of its own now — this list is a list.
+        expect(textOf(tree, 'author-row-powers-0')).toContain('Grenade');
+        expect(textOf(tree, 'author-row-powers-0')).toContain('37');
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-powers-0'})).toHaveLength(0);
     });
 
-    it('draws the defence fields for Resistant Protection, and blocks a save without them', async () => {
+    it('opens the trait form when a row is tapped', async () => {
+        const {tree, edits} = await renderScreen({initial: grenade});
+
+        await press(tree, 'author-row-powers-0');
+
+        expect(edits).toEqual([{address: {kind: 'trait', key: 'powers', index: 0}, category: 'powers'}]);
+    });
+
+    it('blocks a save on a Resistant Protection with no defences', async () => {
         const {tree, saved} = await renderScreen({
             initial: {...emptyDraft('6E'), name: 'Bare', powers: [{xmlid: 'FORCEFIELD', name: 'Skin', input: '', adders: [], levels: 0, modifiers: []}]},
         });
-
-        for (const field of ['pd', 'ed', 'mental', 'power']) {
-            expect(tree.root.findAllByProps({testID: `author-defense-powers-0-${field}`}).length).toBeGreaterThan(0);
-        }
 
         expect(textOf(tree, 'author-problem-error-0')).toContain('grants no defence');
         await press(tree, 'author-save');
@@ -402,12 +425,15 @@ describe('AuthorCharacterScreen — frameworks', () => {
         expect(textOf(tree, 'author-spend')).toBe('71 spent of 400');
     });
 
-    it('edits a slot with the same row a standalone power uses', async () => {
-        const {tree} = await renderScreen({initial: gadgets});
+    it('lists each slot as a row, and opens the trait form for it', async () => {
+        const {tree, edits} = await renderScreen({initial: gadgets});
 
-        // Slots are powers: they get a name, and a modifier list of their own.
-        expect(tree.root.findAllByProps({testID: 'author-name-framework-0-slot-0'}).length).toBeGreaterThan(0);
-        expect(tree.root.findAllByProps({testID: 'author-add-modifier-framework-0-slot-0'}).length).toBeGreaterThan(0);
+        expect(textOf(tree, 'author-row-framework-0-slot-0')).toContain('Stun Gun');
+        // 60 active / 10 for a fixed slot.
+        expect(textOf(tree, 'author-row-framework-0-slot-0')).toContain('6');
+
+        await press(tree, 'author-row-framework-0-slot-1');
+        expect(edits).toEqual([{address: {kind: 'slot', framework: 0, index: 1}, category: 'powers'}]);
     });
 
     it('says slots are fixed slots rather than silently making them so', async () => {

--- a/src/app/screens/__tests__/AuthorTraitScreen.test.tsx
+++ b/src/app/screens/__tests__/AuthorTraitScreen.test.tsx
@@ -1,0 +1,195 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The form for one trait, on its own screen.
+ *
+ * These are the tests that used to drive the inline forms on the authoring screen. What is worth
+ * checking is that the form reaches the shared draft — it edits by *address*, not by a prop
+ * handed down — and that it draws whatever the catalogue says a trait declares.
+ */
+import React from 'react';
+import TestRenderer, {act, type ReactTestRenderer} from 'react-test-renderer';
+import {emptyDraft, type AuthoredCharacter} from 'core/authoring';
+import {AuthoringDraftProvider, useAuthoringDraft, type TraitAddress} from 'app/providers/AuthoringDraftProvider';
+import {ThemeProvider} from 'app/theme';
+import {AuthorTraitScreen, type AuthorTraitScreenProps} from '../AuthorTraitScreen';
+
+/** Renders the screen over a real draft, and hands back a way to read the draft after edits. */
+const renderTrait = async (
+    initial: AuthoredCharacter,
+    address: TraitAddress,
+    category: AuthorTraitScreenProps['category'] = 'powers',
+): Promise<{tree: ReactTestRenderer; draft: () => AuthoredCharacter; done: () => number}> => {
+    let current = initial;
+    let doneCount = 0;
+
+    const Probe = (): null => {
+        current = useAuthoringDraft().draft;
+        return null;
+    };
+
+    let tree!: ReactTestRenderer;
+    await act(async () => {
+        tree = TestRenderer.create(
+            <ThemeProvider colorScheme="dark">
+                <AuthoringDraftProvider initial={initial}>
+                    <Probe />
+                    <AuthorTraitScreen address={address} category={category} onDone={() => (doneCount += 1)} />
+                </AuthoringDraftProvider>
+            </ThemeProvider>,
+        );
+    });
+    await act(async () => {});
+
+    return {tree, draft: () => current, done: () => doneCount};
+};
+
+const type = async (tree: ReactTestRenderer, testID: string, value: string): Promise<void> => {
+    await act(async () => {
+        tree.root
+            .findAllByProps({testID})
+            .find((node) => typeof node.props.onChangeText === 'function')
+            ?.props.onChangeText(value);
+    });
+};
+
+const press = async (tree: ReactTestRenderer, testID: string): Promise<void> => {
+    await act(async () => {
+        tree.root
+            .findAllByProps({testID})
+            .find((node) => typeof node.props.onPress === 'function')
+            ?.props.onPress();
+    });
+    await act(async () => {});
+};
+
+const withPower = (): AuthoredCharacter => ({
+    ...emptyDraft('6E'),
+    powers: [{xmlid: 'ENERGYBLAST', name: 'Bolt', input: 'ED', adders: [], levels: 5, modifiers: []}],
+});
+
+describe('AuthorTraitScreen — editing reaches the shared draft', () => {
+    it('writes a name change back to the draft', async () => {
+        const {tree, draft} = await renderTrait(withPower(), {kind: 'trait', key: 'powers', index: 0});
+
+        await type(tree, 'author-name-powers-0', 'Fire Bolt');
+
+        // The screen has no draft prop and no callback — it addresses the provider directly.
+        expect(draft().powers[0].name).toBe('Fire Bolt');
+    });
+
+    it('writes a levels change back to the draft', async () => {
+        const {tree, draft} = await renderTrait(withPower(), {kind: 'trait', key: 'powers', index: 0});
+
+        await type(tree, 'author-levels-powers-0', '12');
+
+        expect(draft().powers[0].levels).toBe(12);
+    });
+
+    it('removes the trait and leaves, so the list is not left showing a gap', async () => {
+        const {tree, draft, done} = await renderTrait(withPower(), {kind: 'trait', key: 'powers', index: 0});
+
+        await press(tree, 'author-remove-powers-0');
+
+        expect(draft().powers).toEqual([]);
+        expect(done()).toBe(1);
+    });
+
+    it('edits a framework slot through its two-part address', async () => {
+        const initial: AuthoredCharacter = {
+            ...emptyDraft('6E'),
+            frameworks: [
+                {
+                    kind: 'multipower',
+                    name: 'Belt',
+                    reserve: 60,
+                    modifiers: [],
+                    slots: [
+                        {xmlid: 'ENERGYBLAST', name: 'Stun Gun', input: 'ED', adders: [], levels: 12, modifiers: []},
+                        {xmlid: 'ENERGYBLAST', name: 'Net', input: 'ED', adders: [], levels: 10, modifiers: []},
+                    ],
+                },
+            ],
+        };
+        const {tree, draft} = await renderTrait(initial, {kind: 'slot', framework: 0, index: 1});
+
+        await type(tree, 'author-name-framework-0-slot-1', 'Bola');
+
+        expect(draft().frameworks[0].slots.map((slot) => slot.name)).toEqual(['Stun Gun', 'Bola']);
+    });
+});
+
+describe('AuthorTraitScreen — it draws what the catalogue declares', () => {
+    it('offers modifiers on a power', async () => {
+        const {tree} = await renderTrait(withPower(), {kind: 'trait', key: 'powers', index: 0});
+
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-powers-0'}).length).toBeGreaterThan(0);
+    });
+
+    it('offers no modifiers on a skill, because a skill cannot take one', async () => {
+        const initial: AuthoredCharacter = {...emptyDraft('6E'), skills: [{xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 0}]};
+        const {tree} = await renderTrait(initial, {kind: 'trait', key: 'skills', index: 0}, 'skills');
+
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-skills-0'})).toHaveLength(0);
+    });
+
+    it('draws the four defence fields for a Resistant Protection, and writes them back', async () => {
+        const initial: AuthoredCharacter = {
+            ...emptyDraft('6E'),
+            powers: [{xmlid: 'FORCEFIELD', name: 'Vest', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 0, ed: 0, mental: 0, power: 0}}],
+        };
+        const {tree, draft} = await renderTrait(initial, {kind: 'trait', key: 'powers', index: 0});
+
+        for (const field of ['pd', 'ed', 'mental', 'power']) {
+            expect(tree.root.findAllByProps({testID: `author-defense-powers-0-${field}`}).length).toBeGreaterThan(0);
+        }
+
+        await type(tree, 'author-defense-powers-0-pd', '17');
+        expect(draft().powers[0].defense).toEqual({pd: 17, ed: 0, mental: 0, power: 0});
+    });
+});
+
+describe('AuthorTraitScreen — a framework pool', () => {
+    const withFramework = (): AuthoredCharacter => ({
+        ...emptyDraft('6E'),
+        frameworks: [{kind: 'multipower', name: 'Belt', reserve: 60, modifiers: [], slots: []}],
+    });
+
+    it("edits the pool's advantages and limitations, which are not a trait", async () => {
+        const {tree} = await renderTrait(withFramework(), {kind: 'pool', framework: 0});
+
+        // A pool has no catalogue entry, no levels and nothing to pick — only modifiers apply.
+        expect(tree.root.findAllByProps({testID: 'author-add-modifier-framework-0'}).length).toBeGreaterThan(0);
+        expect(tree.root.findAllByProps({testID: 'author-name-framework-0'})).toHaveLength(0);
+    });
+});
+
+describe('AuthorTraitScreen — a stale address', () => {
+    it('says so and offers a way out rather than throwing', async () => {
+        // Addresses are indices, so one can outlive the trait it pointed at.
+        const {tree, done} = await renderTrait(withPower(), {kind: 'trait', key: 'powers', index: 7});
+
+        expect(tree.root.findAllByProps({testID: 'author-trait-missing'}).length).toBeGreaterThan(0);
+
+        await press(tree, 'author-trait-done');
+        expect(done()).toBe(1);
+    });
+
+    it('says the same for a framework that has gone', async () => {
+        const {tree} = await renderTrait(withPower(), {kind: 'pool', framework: 3});
+
+        expect(tree.root.findAllByProps({testID: 'author-trait-missing'}).length).toBeGreaterThan(0);
+    });
+});

--- a/src/app/screens/__tests__/CharacterDetailScreen.test.tsx
+++ b/src/app/screens/__tests__/CharacterDetailScreen.test.tsx
@@ -74,6 +74,7 @@ const character = (over: Partial<Character> = {}): Character => ({
     // Defensor is an import — the read-only default. Generated cases override both.
     origin: 'imported',
     recipe: null,
+    source: null,
     ...over,
 });
 

--- a/src/app/screens/__tests__/CharacterEditor.test.tsx
+++ b/src/app/screens/__tests__/CharacterEditor.test.tsx
@@ -44,6 +44,7 @@ const seededRng = (seed: number): Rng => {
 const RECIPE = rollRecipe(seededRng(3));
 
 const character = (over: Partial<Character> = {}): Character => ({
+    source: null,
     id: 'generated-brick-1',
     name: RECIPE.name,
     player: null,

--- a/src/app/screens/characterSheet.ts
+++ b/src/app/screens/characterSheet.ts
@@ -14,7 +14,7 @@
 
 import {combatDetails} from 'core/combat';
 import {RollType} from 'core/dice';
-import {enduranceCost, heroDesignerCharacter, movementEnduranceCost, strengthEnduranceCost} from 'core/hero';
+import {enduranceCost, heroDesignerCharacter, movementEnduranceCost, strengthEnduranceCost, TRAIT_CHILD_KEYS} from 'core/hero';
 import {characterTraitDecorator, type Attribute, type Obj, type RollDescriptor, type Writeup} from 'core/traits';
 import type {CharacterDocument} from 'core/ports';
 
@@ -36,10 +36,22 @@ export function isOnlyInAlternateId(trait: Obj): boolean {
     return false;
 }
 
-const filterOutAlternateId = (items: Obj[]): Obj[] =>
+/** The keys a category nests children under, defaulting to `powers` for anything unlisted. */
+const childKeysFor = (listKey: string): readonly string[] => TRAIT_CHILD_KEYS[listKey] ?? ['powers'];
+
+const filterOutAlternateId = (items: Obj[], listKey: string): Obj[] =>
     items
         .filter((item) => !isOnlyInAlternateId(item))
-        .map((item) => (Array.isArray(item.powers) ? {...item, powers: filterOutAlternateId(item.powers as Obj[])} : item));
+        .map((item) => {
+            const nested: Obj = {...item};
+            for (const key of childKeysFor(listKey)) {
+                if (Array.isArray(item[key])) {
+                    nested[key] = filterOutAlternateId(item[key] as Obj[], listKey);
+                }
+            }
+
+            return nested;
+        });
 
 /**
  * True when `predicate` holds for any trait in `items`, or for any trait nested inside
@@ -47,8 +59,8 @@ const filterOutAlternateId = (items: Obj[]): Obj[] =>
  * does — `core/util.flatten` is not a substitute, as it only splices `type: 'list'`
  * containers and never visits the children of anything else.
  */
-const someTrait = (items: Obj[], predicate: (item: Obj) => boolean): boolean =>
-    items.some((item) => predicate(item) || (Array.isArray(item.powers) ? someTrait(item.powers as Obj[], predicate) : false));
+const someTrait = (items: Obj[], predicate: (item: Obj) => boolean, listKey: string): boolean =>
+    items.some((item) => predicate(item) || childKeysFor(listKey).some((key) => (Array.isArray(item[key]) ? someTrait(item[key] as Obj[], predicate, listKey) : false)));
 
 /**
  * A copy of the character with every "Only In Alternate Identity" trait removed
@@ -61,7 +73,7 @@ function withoutAlternateIdTraits(character: Obj): Obj {
     const stripped: Obj = {...character};
     for (const key of TRAIT_KEYS) {
         if (Array.isArray(character[key])) {
-            stripped[key] = filterOutAlternateId(character[key] as Obj[]);
+            stripped[key] = filterOutAlternateId(character[key] as Obj[], key);
         }
     }
 
@@ -75,7 +87,7 @@ function withoutAlternateIdTraits(character: Obj): Obj {
  * to switch to, so for those characters the sheet shows the alternate-ID form outright.
  */
 export function hasAlternateForm(character: Obj): boolean {
-    return TRAIT_KEYS.some((key) => someTrait(toArray(character[key]), isOnlyInAlternateId));
+    return TRAIT_KEYS.some((key) => someTrait(toArray(character[key]), isOnlyInAlternateId, key));
 }
 
 /** The character's alias / alternate identity (super name) from the parsed info, or null. */
@@ -366,7 +378,10 @@ function buildTraits(items: Obj[], listKey: string, character: Obj, depth: numbe
             const endurance = listKey === 'powers' ? enduranceCost(item, decorated.activeCost()) : 0;
             rows.push({label: decorated.label(), roll, realCost: decorated.realCost(), endurance, definition: decorated.definition(), depth, writeup: decorated.toWriteup(), maneuver});
 
-            const children = toArray(item.powers);
+            // Indent whatever this category nests its children under — `powers` only for Powers.
+            // A Skill Enhancer nests under `skills` and a martial style under `maneuver`, so
+            // reading `item.powers` everywhere would drop those rows off the sheet entirely.
+            const children = (TRAIT_CHILD_KEYS[listKey] ?? ['powers']).flatMap((key) => toArray(item[key]));
             if (children.length > 0) {
                 rows.push(...buildTraits(children, listKey, character, depth + 1));
             }

--- a/src/core/authoring/__tests__/emit.test.ts
+++ b/src/core/authoring/__tests__/emit.test.ts
@@ -23,7 +23,8 @@
  * *quietly*: a missing category throws deep in the engine, a missing `name` renders the literal
  * string "undefined", a missing alias prints an xmlid, and unstable ids break re-opening.
  */
-import {build, emit, emptyDraft, parseSource, remaining, spendOf, toSource, type AuthoredCharacter} from 'core/authoring';
+import {build, declaredFor, emit, emptyDraft, parseSource, remaining, spendOf, toSource, type AuthoredCharacter} from 'core/authoring';
+import {powerTier} from 'core/hero';
 import {characterTraitDecorator} from 'core/traits';
 
 type Obj = Record<string, any>;
@@ -228,6 +229,30 @@ describe('spend — the running total the app shows', () => {
         expect(remaining(spend, {base: 400, complicationLimit: 75}, '6E')).toMatchObject({total: 400, left: 250});
         // 5E: disadvantages buy points, so the same character has 200 + 60 to spend.
         expect(remaining(spend, {base: 200, complicationLimit: 150}, '5E')).toMatchObject({total: 260, left: 110});
+    });
+
+    it('counts anything past the allowance as experience rather than an overspend', () => {
+        const spend = {characteristics: 300, traits: 125, complications: 75, spent: 425};
+        const over = remaining(spend, {base: 400, complicationLimit: 75}, '6E');
+
+        // In HERO a character costing more than their starting points has *earned* the difference.
+        expect(over).toMatchObject({total: 400, spent: 425, left: 0, experience: 25});
+        // `left` never goes negative — past the allowance there is nothing left, only experience.
+        expect(over.left).toBe(0);
+    });
+
+    it('declares that experience, which is what the nameplate prints beside the base', () => {
+        // The sheet renders "400 + 25 pts" from exactly these two numbers.
+        expect(declaredFor({base: 400, complicationLimit: 75}, 25)).toEqual({basePoints: 400, disadPoints: 75, experience: 25});
+        // And a character inside its allowance has earned nothing.
+        expect(declaredFor({base: 400, complicationLimit: 75})).toEqual({basePoints: 400, disadPoints: 75, experience: 0});
+    });
+
+    it('keeps the campaign tier keyed on base, so earning points does not promote a character', () => {
+        const config = declaredFor({base: 400, complicationLimit: 75}, 250);
+
+        // 650 would be Very High-Powered on the 6E ladder; 400 is Standard, and that is what it is.
+        expect(powerTier(config.basePoints, false)).toBe('Standard Superheroic');
     });
 
     it('stops counting 5E disadvantages past the limit', () => {

--- a/src/core/authoring/__tests__/emit.test.ts
+++ b/src/core/authoring/__tests__/emit.test.ts
@@ -1,0 +1,258 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The emitter produces something the engine prices correctly.
+ *
+ * Values are derived from the HERO rules, not from legacy and not from the generator —
+ * `core/random` is no more an oracle for authoring than legacy is for `core/random`. Where a
+ * number is asserted, the arithmetic behind it is in the comment.
+ *
+ * The four `.hdc` habits `emit` exists to satisfy each get a test, because each of them fails
+ * *quietly*: a missing category throws deep in the engine, a missing `name` renders the literal
+ * string "undefined", a missing alias prints an xmlid, and unstable ids break re-opening.
+ */
+import {build, emit, emptyDraft, parseSource, remaining, spendOf, toSource, type AuthoredCharacter} from 'core/authoring';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const draft = (over: Partial<AuthoredCharacter> = {}): AuthoredCharacter => ({...emptyDraft('6E'), name: 'Probe', ...over});
+
+const characteristic = (character: Obj, key: string): Obj =>
+    (character.characteristics as Obj[]).find((entry) => String(entry.shortName).toLowerCase() === key)!;
+
+describe('emit — the .hdc habits the engine relies on', () => {
+    it('emits all seven trait categories, so populateTrait never sees undefined', () => {
+        const parsed = emit(draft()) as unknown as Obj;
+
+        for (const key of ['skills', 'perks', 'talents', 'martialarts', 'powers', 'equipment', 'disadvantages']) {
+            expect({[key]: parsed[key] === undefined}).toEqual({[key]: false});
+        }
+    });
+
+    it('sets name to null rather than leaving it absent', () => {
+        const parsed = emit(draft({complications: [{xmlid: 'UNLUCK', input: '', adders: [], levels: 2}]})) as unknown as Obj;
+        const [complication] = parsed.disadvantages.disad as Obj[];
+
+        // Absent (not null) is what renders "undefined (…)" in a label.
+        expect(Object.prototype.hasOwnProperty.call(complication, 'name')).toBe(true);
+        expect(complication.name).toBeNull();
+        expect(Object.prototype.hasOwnProperty.call(parsed.characteristics.str, 'name')).toBe(true);
+        expect(parsed.characteristics.str.name).toBeNull();
+    });
+
+    it('copies the template display into alias, which the engine prints but never derives', () => {
+        const parsed = emit(
+            draft({
+                complications: [
+                    {
+                        xmlid: 'PSYCHOLOGICALLIMITATION',
+                        input: 'Code Of The Hero',
+                        adders: [
+                            {xmlid: 'SITUATION', option: 'COMMON'},
+                            {xmlid: 'INTENSITY', option: 'STRONG'},
+                        ],
+                    },
+                ],
+            }),
+        ) as unknown as Obj;
+        const [complication] = parsed.disadvantages.disad as Obj[];
+
+        expect(complication.alias).toBe('Psychological Complication');
+        expect((complication.adder as Obj[]).map((adder) => adder.alias)).toEqual(['Situation Is', 'Intensity Is']);
+        // optionAlias is read by the writeup, and by RIVALRY's label, which slices it.
+        expect((complication.adder as Obj[]).map((adder) => adder.optionAlias)).toEqual(['Common', 'Strong']);
+    });
+
+    it('is pure — the same draft emits the same document, ids and all', () => {
+        const subject = draft({
+            characteristics: {str: 20, dex: 18},
+            complications: [{xmlid: 'HUNTED', input: 'Arch Enemy', adders: [{xmlid: 'APPEARANCE', option: 'EIGHT'}]}],
+        });
+
+        expect(emit(subject)).toEqual(emit(subject));
+    });
+});
+
+describe('emit — characteristics are stated as totals', () => {
+    it('lands 6E characteristics exactly on their targets, and prices them per the rules', () => {
+        const character = build(draft({characteristics: {str: 20, dex: 18, con: 20}}));
+
+        expect(characteristic(character, 'str').value).toBe(20);
+        expect(characteristic(character, 'dex').value).toBe(18);
+        expect(characteristic(character, 'con').value).toBe(20);
+
+        // 6E sells STR at 1/point over a base of 10, DEX at 2/point over 10, CON at 1/point over 10.
+        expect(characteristic(character, 'str').cost).toBe(10);
+        expect(characteristic(character, 'dex').cost).toBe(16);
+        expect(characteristic(character, 'con').cost).toBe(10);
+    });
+
+    it("lands 5E's figured characteristics on their targets too, without knowing how they're figured", () => {
+        // 5E figures ED from CON/5 and STUN from BODY + STR/2 + CON/2, so the levels needed to
+        // reach a stated total depend on other characteristics. The emitter probes rather than
+        // reimplements — the point of this test is that it arrives, not how.
+        const character = build(draft({edition: '5E', characteristics: {str: 30, con: 25, body: 12, ed: 10, stun: 50}}));
+
+        expect(characteristic(character, 'str').value).toBe(30);
+        expect(characteristic(character, 'ed').value).toBe(10);
+        expect(characteristic(character, 'stun').value).toBe(50);
+    });
+
+    it('leaves an unstated characteristic at its base', () => {
+        const character = build(draft({characteristics: {str: 20}}));
+
+        expect(characteristic(character, 'dex').value).toBe(10); // 6E DEX base
+        expect(characteristic(character, 'dex').cost).toBe(0);
+    });
+
+    it('omits COM in 6E and OCV in 5E, because the template does', () => {
+        const sixth = emit(draft({edition: '6E'})) as unknown as Obj;
+        const fifth = emit(draft({edition: '5E'})) as unknown as Obj;
+
+        expect(sixth.characteristics.com).toBeUndefined();
+        expect(sixth.characteristics.ocv).toBeDefined();
+        expect(fifth.characteristics.com).toBeDefined();
+        expect(fifth.characteristics.ocv).toBeUndefined();
+    });
+});
+
+describe('emit — complications price and label through the engine', () => {
+    const psych = draft({
+        complications: [
+            {
+                xmlid: 'PSYCHOLOGICALLIMITATION',
+                input: 'Code Of The Hero',
+                adders: [
+                    {xmlid: 'SITUATION', option: 'COMMON'},
+                    {xmlid: 'INTENSITY', option: 'STRONG'},
+                ],
+            },
+        ],
+    });
+
+    it('prices a complication as the sum of its adders', () => {
+        const character = build(psych);
+        const [complication] = character.disadvantages as Obj[];
+
+        // 6E: Situation Common 10 + Intensity Strong 5. The engine sums the adders; nothing here does.
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).cost()).toBe(15);
+    });
+
+    it('labels it from its type and its input', () => {
+        const character = build(psych);
+        const [complication] = character.disadvantages as Obj[];
+
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).label()).toBe('Psychological: Code Of The Hero');
+    });
+
+    it("emits Rivalry's free-text description behind the bracket the reader slices off", () => {
+        const subject = draft({
+            complications: [
+                {
+                    xmlid: 'RIVALRY',
+                    input: '',
+                    adders: [
+                        {xmlid: 'SITUATION', option: 'PROFESSIONAL'},
+                        {xmlid: 'DESCRIPTION', text: 'Doctor Destroyer'},
+                        {xmlid: 'POWER', option: 'AS'},
+                        {xmlid: 'FIERCENESS', option: 'OUTDO'},
+                        {xmlid: 'KNOWLEDGE', option: 'AWARE'},
+                    ],
+                },
+            ],
+        });
+        const parsed = emit(subject) as unknown as Obj;
+        const description = ((parsed.disadvantages.disad as Obj[])[0].adder as Obj[]).find((adder) => adder.xmlid === 'DESCRIPTION')!;
+
+        // The bracket is the format's, not ours: `Complication.label()` does `.slice(1)`.
+        expect(description.optionAlias).toBe('(Doctor Destroyer');
+
+        const character = build(subject);
+        const [complication] = character.disadvantages as Obj[];
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).label()).toBe('Rivalry: Doctor Destroyer');
+
+        // Situation 5 + Description 0 + Power 0 + Fierceness 0 + Knowledge 0 = 5.
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).cost()).toBe(5);
+    });
+});
+
+describe('spend — the running total the app shows', () => {
+    it("sums the engine's own characteristic costs", () => {
+        const spend = spendOf(build(draft({characteristics: {str: 20, dex: 18}})));
+
+        expect(spend.characteristics).toBe(26); // STR 10 + DEX 16
+        expect(spend.traits).toBe(0);
+        expect(spend.spent).toBe(26);
+    });
+
+    it('counts complications apart from what is spent', () => {
+        const spend = spendOf(
+            build(
+                draft({
+                    characteristics: {str: 20},
+                    complications: [
+                        {
+                            xmlid: 'PSYCHOLOGICALLIMITATION',
+                            input: 'Code Of The Hero',
+                            adders: [
+                                {xmlid: 'SITUATION', option: 'COMMON'},
+                                {xmlid: 'INTENSITY', option: 'STRONG'},
+                            ],
+                        },
+                    ],
+                }),
+            ),
+        );
+
+        expect(spend.complications).toBe(15);
+        expect(spend.spent).toBe(10); // complications fund a build; they are not part of it
+    });
+
+    it('gives 6E complications no points, and 5E disadvantages their full worth', () => {
+        const spend = {characteristics: 100, traits: 50, complications: 60, spent: 150};
+
+        // 6E: the 400 is the whole allowance, complications buy nothing.
+        expect(remaining(spend, {base: 400, complicationLimit: 75}, '6E')).toMatchObject({total: 400, left: 250});
+        // 5E: disadvantages buy points, so the same character has 200 + 60 to spend.
+        expect(remaining(spend, {base: 200, complicationLimit: 150}, '5E')).toMatchObject({total: 260, left: 110});
+    });
+
+    it('stops counting 5E disadvantages past the limit', () => {
+        const spend = {characteristics: 0, traits: 0, complications: 200, spent: 0};
+
+        expect(remaining(spend, {base: 200, complicationLimit: 150}, '5E').total).toBe(350);
+    });
+});
+
+describe('source — a draft survives storage', () => {
+    it('round-trips through the source column', () => {
+        const subject = draft({
+            characteristics: {str: 20, dex: 18},
+            player: 'Phil',
+            complications: [{xmlid: 'HUNTED', input: 'Arch Enemy', adders: [{xmlid: 'APPEARANCE', option: 'EIGHT'}]}],
+        });
+
+        expect(parseSource(JSON.parse(JSON.stringify(toSource(subject))))).toEqual(subject);
+    });
+
+    it('rebuilds the identical document from a stored draft', () => {
+        const subject = draft({characteristics: {str: 25, con: 20}, complications: [{xmlid: 'UNLUCK', input: '', adders: [], levels: 2}]});
+
+        const reopened = parseSource(JSON.parse(JSON.stringify(toSource(subject))))!;
+
+        expect(emit(reopened)).toEqual(emit(subject));
+    });
+});

--- a/src/core/authoring/__tests__/frameworks.test.ts
+++ b/src/core/authoring/__tests__/frameworks.test.ts
@@ -1,0 +1,186 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Power frameworks (Phase D of docs/CHARACTER_AUTHORING.md).
+ *
+ * The three kinds exist because they price slots differently, so that is what these pin. Each
+ * number's arithmetic is in the comment and comes from the HERO rules, not from legacy.
+ *
+ * This is also the first thing in the app that depends on H2 being fixed. Before it, a container
+ * was processed *after* its own slots and never adopted them — every framework came out empty with
+ * its slots loose beside it. The nesting assertions below are the regression test for that.
+ */
+import {build, emptyDraft, parseSource, spendOf, toSource, validate, type AuthoredCharacter, type AuthoredPower} from 'core/authoring';
+import {heroDesignerCharacter} from 'core/hero';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const draft = (over: Partial<AuthoredCharacter> = {}): AuthoredCharacter => ({...emptyDraft('6E'), name: 'Probe', ...over});
+const blast = (over: Partial<AuthoredPower> = {}): AuthoredPower => ({xmlid: 'ENERGYBLAST', name: 'Bolt', input: 'ED', adders: [], levels: 10, modifiers: [], ...over});
+const errors = (subject: AuthoredCharacter): string[] =>
+    validate(subject)
+        .filter((problem) => problem.severity === 'error')
+        .map((problem) => problem.message);
+
+const container = (character: Obj): Obj => (character.powers as Obj[]).find((power) => power.type === 'list')!;
+const cost = (trait: Obj, character: Obj): number => characterTraitDecorator.decorate(trait, 'powers', () => character).realCost();
+const slotCosts = (character: Obj): number[] => ((container(character).powers ?? []) as Obj[]).map((slot) => cost(slot, character));
+
+describe('a framework adopts its slots', () => {
+    const multipower = draft({
+        frameworks: [{kind: 'multipower', name: 'Fire Tricks', reserve: 60, modifiers: [], slots: [blast({name: 'Flame Bolt', levels: 12}), blast({name: 'Fire Blast', levels: 10})]}],
+    });
+
+    it('nests them, rather than leaving them loose beside it', () => {
+        const character = build(multipower);
+
+        // One top-level power: the container. Both slots are inside it. This is precisely what H2
+        // made possible — before the fix this read 3 and 0.
+        expect((character.powers as Obj[]).length).toBe(1);
+        expect((container(character).powers as Obj[]).map((slot) => slot.name)).toEqual(['Flame Bolt', 'Fire Blast']);
+        expect((character.powers as Obj[]).filter((power) => power.parentid !== undefined)).toEqual([]);
+    });
+
+    it('marks the container as the framework it is', () => {
+        const character = build(multipower);
+
+        // The identity is the sub-key it was emitted under, not the xmlid — which is GENERIC_OBJECT
+        // for all three kinds.
+        expect(container(character).xmlid).toBe('GENERIC_OBJECT');
+        expect(container(character).originalType).toBe('multipower');
+        expect(heroDesignerCharacter.isPowerFrameworkItem((container(character).powers as Obj[])[0], character, 'multipower')).toBe(true);
+    });
+});
+
+describe('the three kinds price their slots differently', () => {
+    it('a Multipower slot costs a tenth of what the power would cost alone', () => {
+        const character = build(
+            draft({frameworks: [{kind: 'multipower', name: 'MP', reserve: 60, modifiers: [], slots: [blast({levels: 12}), blast({levels: 10})]}]}),
+        );
+
+        // Reserve 60. A 12d6 Blast is 60 alone, so its fixed slot is 6; a 10d6 is 50, so 5.
+        expect(cost(container(character), character)).toBe(60);
+        expect(slotCosts(character)).toEqual([6, 5]);
+    });
+
+    it('an Elemental Control slot costs whatever it exceeds the pool by', () => {
+        const character = build(
+            draft({frameworks: [{kind: 'elementalControl', name: 'Psychic Powers', reserve: 22, modifiers: [], slots: [blast({levels: 12})]}]}),
+        );
+
+        // The pool pays for the first 22 points of every slot: 60 active - 22 = 38.
+        expect(cost(container(character), character)).toBe(22);
+        expect(slotCosts(character)).toEqual([38]);
+    });
+
+    it('a Variable Power Pool costs its pool plus the control that steers it', () => {
+        const character = build(draft({frameworks: [{kind: 'vpp', name: 'Cosmic', reserve: 50, modifiers: [], slots: []}]}));
+
+        // 50 points of pool, plus a control cost of half that: 75. The size lives in `levels` for a
+        // VPP where the other two kinds put it in `basecost`, and the decorator reads accordingly.
+        expect(cost(container(character), character)).toBe(75);
+    });
+
+    it('counts the container and every slot toward the total', () => {
+        const spend = spendOf(build(draft({frameworks: [{kind: 'multipower', name: 'MP', reserve: 60, modifiers: [], slots: [blast({levels: 12}), blast({levels: 10})]}]})));
+
+        // 60 + 6 + 5. A sum that walked only the top level would say 60 — which is what
+        // `withDescendants` exists to prevent.
+        expect(spend.traits).toBe(71);
+    });
+});
+
+describe('modifiers on a framework and on its slots', () => {
+    it('applies a limitation on the pool to the pool', () => {
+        const character = build(
+            draft({
+                frameworks: [{kind: 'multipower', name: 'Gadgets', reserve: 60, modifiers: [{xmlid: 'FOCUS', option: 'OAF', adders: []}], slots: [blast({levels: 12})]}],
+            }),
+        );
+
+        // 60 / (1 + 1) = 30 for the reserve.
+        expect(cost(container(character), character)).toBe(30);
+    });
+
+    it("applies a slot's own modifiers before the framework divides", () => {
+        const character = build(
+            draft({
+                frameworks: [
+                    {kind: 'multipower', name: 'MP', reserve: 60, modifiers: [], slots: [blast({levels: 10, modifiers: [{xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: []}]})]},
+                ],
+            }),
+        );
+
+        // The Blast is 50, the Area Of Effect makes it 75 active, and the fixed slot is a tenth of
+        // that: 7.5, which HERO rounds *in the player's favour* — a fraction in .50–.59 truncates
+        // down, so 7 rather than 8. The advantage is not free just because the power sits in a pool.
+        expect(slotCosts(character)).toEqual([7]);
+    });
+});
+
+describe('validate — frameworks', () => {
+    it('rejects a framework with no reserve, whose slots would cost nothing to speak of', () => {
+        expect(errors(draft({frameworks: [{kind: 'multipower', name: 'Empty', reserve: 0, modifiers: [], slots: [blast()]}]}))).toEqual([
+            expect.stringContaining('reserve of at least 1'),
+        ]);
+    });
+
+    it('warns about a framework with nothing in it', () => {
+        const lonely = draft({frameworks: [{kind: 'multipower', name: 'Empty', reserve: 60, modifiers: [], slots: []}]});
+
+        expect(errors(lonely)).toEqual([]);
+        expect(validate(lonely).some((problem) => problem.severity === 'warning' && problem.message.includes('no powers in it'))).toBe(true);
+    });
+
+    it('validates the slots too, and points at the framework they are in', () => {
+        const broken = draft({frameworks: [{kind: 'multipower', name: 'MP', reserve: 60, modifiers: [], slots: [blast({modifiers: [{xmlid: 'NOT_A_MODIFIER', adders: []}]})]}]});
+        const problem = validate(broken).find((entry) => entry.severity === 'error')!;
+
+        expect(problem.message).toContain('has no modifier');
+        expect(problem.path).toBe('frameworks[0]');
+    });
+});
+
+describe('frameworks survive storage', () => {
+    const complete = draft({
+        powers: [blast({name: 'Standalone'})],
+        frameworks: [
+            {kind: 'multipower', name: 'Fire Tricks', reserve: 60, modifiers: [{xmlid: 'FOCUS', option: 'OAF', adders: []}], slots: [blast({name: 'Flame Bolt', levels: 12})]},
+            {kind: 'vpp', name: 'Cosmic', reserve: 50, modifiers: [], slots: []},
+        ],
+    });
+
+    it('round-trips, and rebuilds the identical character', () => {
+        const reopened = parseSource(JSON.parse(JSON.stringify(toSource(complete))))!;
+
+        expect(reopened).toEqual(complete);
+        expect(build(reopened)).toEqual(build(complete));
+    });
+
+    it('keeps standalone powers apart from the frameworks', () => {
+        const character = build(complete);
+        const top = character.powers as Obj[];
+
+        expect(top.filter((power) => power.type === 'list').length).toBe(2);
+        expect(top.filter((power) => power.type !== 'list').map((power) => power.name)).toEqual(['Standalone']);
+    });
+
+    it('reads a Phase C source, which had no frameworks key, as empty', () => {
+        const phaseC = {edition: '6E', name: 'Old', player: '', characteristics: {}, skills: [], perks: [], talents: [], powers: [], complications: []};
+
+        expect(parseSource(phaseC)).toEqual({...emptyDraft('6E'), name: 'Old'});
+    });
+});

--- a/src/core/authoring/__tests__/frameworks.test.ts
+++ b/src/core/authoring/__tests__/frameworks.test.ts
@@ -170,6 +170,20 @@ describe('frameworks survive storage', () => {
         expect(build(reopened)).toEqual(build(complete));
     });
 
+    it('orders frameworks after the standalone powers, not among them', () => {
+        const character = build(
+            draft({
+                powers: [blast({name: 'Loose A'}), blast({name: 'Loose B'})],
+                frameworks: [{kind: 'multipower', name: 'MP', reserve: 30, modifiers: [], slots: [blast({name: 'Slot'})]}],
+            }),
+        );
+
+        // Position is the sheet's display order. Frameworks start well above the standalone
+        // powers so a Multipower cannot land between two loose powers — and so its slots'
+        // positions cannot collide with theirs.
+        expect((character.powers as Obj[]).map((power) => power.name)).toEqual(['Loose A', 'Loose B', 'MP']);
+    });
+
     it('keeps standalone powers apart from the frameworks', () => {
         const character = build(complete);
         const top = character.powers as Obj[];

--- a/src/core/authoring/__tests__/martialArtsAndEquipment.test.ts
+++ b/src/core/authoring/__tests__/martialArtsAndEquipment.test.ts
@@ -1,0 +1,193 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Martial arts and equipment (Phase E of docs/CHARACTER_AUTHORING.md).
+ *
+ * Two categories with almost nothing in common. A maneuver is priced by a flat `basecost` and is
+ * interesting only for its **combat line**, which the engine reads off the trait rather than the
+ * template. Equipment is powers in a different bucket, so what is worth testing is that it really
+ * does behave like one — same catalogue, same modifiers, same field groups.
+ */
+import {authorable, build, catalogue, emptyDraft, parseSource, spendOf, toSource, trait, validate, withheld, type AuthoredCharacter, type AuthoredPower} from 'core/authoring';
+import {heroDesignerCharacter} from 'core/hero';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const draft = (over: Partial<AuthoredCharacter> = {}): AuthoredCharacter => ({...emptyDraft('6E'), name: 'Probe', ...over});
+const errors = (subject: AuthoredCharacter): string[] =>
+    validate(subject)
+        .filter((problem) => problem.severity === 'error')
+        .map((problem) => problem.message);
+
+const attributes = (character: Obj, key: string, index = 0): Record<string, string> => {
+    const decorated = characterTraitDecorator.decorate((character[key] as Obj[])[index], key, () => character);
+
+    return Object.fromEntries(decorated.attributes().map((attribute) => [attribute.label, String(attribute.value)]));
+};
+
+const costOf = (character: Obj, key: string, index = 0): number =>
+    characterTraitDecorator.decorate((character[key] as Obj[])[index], key, () => character).realCost();
+
+describe('martial maneuvers', () => {
+    it("derives a maneuver's xmlid from its display, as the engine does", () => {
+        // The template states no xmlid at all — `normalizeTemplateItem` builds one from `display`.
+        // "Basic Strike" becomes BASIC_STRIKE, and the emitted trait says `xmlid: 'MANEUVER'` plus
+        // a display so the engine derives it exactly once, in its own code.
+        expect(trait('BASIC_STRIKE', 'martialArts', '6E')?.display).toBe('Basic Strike');
+        expect(trait('CHOKE_HOLD', 'martialArts', '6E')).not.toBeNull();
+    });
+
+    it('prices a maneuver at its flat cost', () => {
+        const character = build(
+            draft({
+                martialArts: [
+                    {xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0},
+                    {xmlid: 'MARTIAL_DODGE', input: '', adders: [], levels: 0},
+                ],
+            }),
+        );
+
+        expect(costOf(character, 'martialArts', 0)).toBe(3); // Basic Strike
+        expect(costOf(character, 'martialArts', 1)).toBe(4); // Martial Dodge
+    });
+
+    it('carries the combat line, which the engine reads off the trait and not the template', () => {
+        const character = build(draft({characteristics: {str: 20}, martialArts: [{xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0}]}));
+
+        // A maneuver emitted without these renders with no OCV, no DCV and no effect, priced
+        // correctly — the quiet failure this copying exists to prevent.
+        expect(attributes(character, 'martialArts')).toMatchObject({Phase: '½', OCV: '+1', DCV: '+0'});
+    });
+
+    it('folds STR into the damage, so the same maneuver hits harder on a stronger character', () => {
+        const weak = build(draft({characteristics: {str: 10}, martialArts: [{xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0}]}));
+        const strong = build(draft({characteristics: {str: 20}, martialArts: [{xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0}]}));
+
+        // Basic Strike is +2 DC. STR 10 gives 2 DC, so 4d6; STR 20 gives 4, so 6d6.
+        expect(attributes(weak, 'martialArts').Effect).toBe('4d6 Strike');
+        expect(attributes(strong, 'martialArts').Effect).toBe('6d6 Strike');
+    });
+
+    it('offers both editions their maneuvers and withholds only what needs its own form', () => {
+        for (const edition of ['5E', '6E'] as const) {
+            expect(authorable('martialArts', edition).length).toBe(catalogue('martialArts', edition).length - 1);
+        }
+
+        // Weapon Element wants a list of the weapons a style covers, which no template describes.
+        expect(withheld('martialArts', '6E').map((entry) => entry.xmlid)).toEqual(['WEAPON_ELEMENT']);
+    });
+
+    it('rejects a maneuver this edition does not have', () => {
+        expect(errors(draft({martialArts: [{xmlid: 'NOT_A_MANEUVER', input: '', adders: [], levels: 0}]}))).toEqual([expect.stringContaining('has no maneuver')]);
+    });
+});
+
+describe('equipment is powers in a different bucket', () => {
+    const vest: AuthoredPower = {
+        xmlid: 'FORCEFIELD',
+        name: 'Leather Vest',
+        input: '',
+        adders: [],
+        levels: 0,
+        modifiers: [],
+        defense: {pd: 4, ed: 4, mental: 0, power: 0},
+    };
+
+    it('prices an item exactly as the same power would price', () => {
+        const carried = build(draft({equipment: [vest]}));
+        const innate = build(draft({powers: [vest]}));
+
+        // 8 points of resistant defence at 3 per 2 = 12, wherever it is kept.
+        expect(costOf(carried, 'equipment')).toBe(12);
+        expect(costOf(innate, 'powers')).toBe(12);
+    });
+
+    it("does NOT add its defence to the character's totals, which is the engine's own limit", () => {
+        const carried = build(draft({equipment: [vest]}));
+        const innate = build(draft({powers: [vest]}));
+
+        // Same item, same cost, different effect on the sheet. `powersForTotals` reads
+        // `character.powers` and nothing in the engine ever reads `character.equipment`, so a vest
+        // costs its points and defends nothing. The identical power bought innately defends 4.
+        //
+        // Pinned rather than worked around: it is faithful to legacy and the golden masters agree,
+        // so changing it is a correctness-pass decision with a rules question attached, not
+        // something an authoring layer should quietly paper over. `validate` warns instead.
+        expect(heroDesignerCharacter.getTotalDefense(carried, 'PD')).toBe('2/0');
+        expect(heroDesignerCharacter.getTotalDefense(innate, 'PD')).toBe('6/4');
+    });
+
+    it('warns that a defensive item will not count, rather than letting it surprise anyone', () => {
+        const problems = validate(draft({equipment: [vest]}));
+
+        expect(problems.filter((problem) => problem.severity === 'error')).toEqual([]);
+        expect(problems.some((problem) => problem.severity === 'warning' && problem.message.includes('will not add to'))).toBe(true);
+    });
+
+    it('takes modifiers like a power', () => {
+        const character = build(draft({equipment: [{...vest, modifiers: [{xmlid: 'FOCUS', option: 'OAF', adders: []}]}]}));
+
+        expect(costOf(character, 'equipment')).toBe(6); // 12 / (1 + 1)
+    });
+
+    it('is validated by the powers rules, and says where the problem is', () => {
+        const problem = validate(draft({equipment: [{xmlid: 'FORCEFIELD', name: 'Hollow', input: '', adders: [], levels: 0, modifiers: []}]})).find(
+            (entry) => entry.severity === 'error',
+        )!;
+
+        expect(problem.message).toContain('grants no defence');
+        expect(problem.path).toBe('equipment[0]');
+    });
+
+    it('stays a separate list from powers on the built character', () => {
+        const character = build(draft({powers: [{xmlid: 'ENERGYBLAST', name: 'Bolt', input: 'ED', adders: [], levels: 10, modifiers: []}], equipment: [vest]}));
+
+        expect((character.powers as Obj[]).map((power) => power.name)).toEqual(['Bolt']);
+        expect((character.equipment as Obj[]).map((item) => item.name)).toEqual(['Leather Vest']);
+    });
+});
+
+describe('a character with everything', () => {
+    const everything = draft({
+        characteristics: {str: 20, dex: 18},
+        skills: [{xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 0}],
+        martialArts: [{xmlid: 'BASIC_STRIKE', input: '', adders: [], levels: 0}],
+        equipment: [{xmlid: 'FORCEFIELD', name: 'Vest', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 4, ed: 4, mental: 0, power: 0}}],
+        frameworks: [{kind: 'multipower', name: 'Belt', reserve: 30, modifiers: [], slots: [{xmlid: 'ENERGYBLAST', name: 'Dart', input: 'ED', adders: [], levels: 6, modifiers: []}]}],
+    });
+
+    it('totals every bucket', () => {
+        const spend = spendOf(build(everything));
+
+        // STR 10 + DEX 16 = 26 characteristics.
+        expect(spend.characteristics).toBe(26);
+        // Acrobatics 3 + Basic Strike 3 + Vest 12 + Belt 30 + Dart (30 active / 10) 3 = 51.
+        expect(spend.traits).toBe(51);
+    });
+
+    it('round-trips through storage and rebuilds identically', () => {
+        const reopened = parseSource(JSON.parse(JSON.stringify(toSource(everything))))!;
+
+        expect(reopened).toEqual(everything);
+        expect(build(reopened)).toEqual(build(everything));
+    });
+
+    it('reads a Phase D source, which had no martialArts or equipment keys, as empty', () => {
+        const phaseD = {edition: '6E', name: 'Old', player: '', characteristics: {}, skills: [], perks: [], talents: [], powers: [], frameworks: [], complications: []};
+
+        expect(parseSource(phaseD)).toEqual({...emptyDraft('6E'), name: 'Old'});
+    });
+});

--- a/src/core/authoring/__tests__/powers.test.ts
+++ b/src/core/authoring/__tests__/powers.test.ts
@@ -1,0 +1,227 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Powers, and the advantages and limitations that price them (Phase C of
+ * docs/CHARACTER_AUTHORING.md).
+ *
+ * Every number is derived from the HERO rules and the arithmetic is in the comment. The three
+ * costs a power has are all pinned, because they answer different questions and only the middle
+ * one moves with an advantage: `cost` is what the dice are worth, `activeCost` is that times the
+ * advantages, `realCost` is that divided by the limitations.
+ */
+import {authorable, build, emptyDraft, modifier, modifiers, parseSource, spendOf, toSource, trait, validate, withheld, type AuthoredCharacter, type AuthoredPower} from 'core/authoring';
+import {heroDesignerCharacter} from 'core/hero';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const draft = (over: Partial<AuthoredCharacter> = {}): AuthoredCharacter => ({...emptyDraft('6E'), name: 'Probe', ...over});
+const errors = (subject: AuthoredCharacter): string[] =>
+    validate(subject)
+        .filter((problem) => problem.severity === 'error')
+        .map((problem) => problem.message);
+
+/** The three costs of every power, in the order the sheet thinks about them. */
+const priced = (character: Obj): Array<{label: string; base: number; active: number; real: number}> =>
+    (character.powers as Obj[]).map((power) => {
+        const decorated = characterTraitDecorator.decorate(power, 'powers', () => character);
+
+        return {label: decorated.label(), base: decorated.cost(), active: decorated.activeCost(), real: decorated.realCost()};
+    });
+
+const blast = (over: Partial<AuthoredPower> = {}): AuthoredPower => ({xmlid: 'ENERGYBLAST', name: 'Bolt', input: 'ED', adders: [], levels: 10, modifiers: [], ...over});
+
+describe('powers price by their dice', () => {
+    it('prices a Blast at 5 points a die, and names it', () => {
+        const character = build(draft({powers: [blast()]}));
+
+        // 6E Blast is 5 points per 1d6. Ten dice, no modifiers: all three costs agree.
+        expect(priced(character)).toEqual([{label: 'Bolt', base: 50, active: 50, real: 50}]);
+    });
+
+    it('prices Resistant Protection by its defences, and grants them', () => {
+        const character = build(
+            draft({powers: [{xmlid: 'FORCEFIELD', name: 'Dense Body', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 17, ed: 17, mental: 0, power: 0}}]}),
+        );
+
+        // 6E Resistant Protection is 3 points per 2 points of defence: 34 total → 51.
+        expect(priced(character)[0]).toMatchObject({base: 51, real: 51});
+        // And the point of the field group: it actually defends. 2 base PD + 17 resistant.
+        expect(heroDesignerCharacter.getTotalDefense(character, 'PD')).toBe('19/17');
+        expect(heroDesignerCharacter.getTotalDefense(character, 'ED')).toBe('19/17');
+    });
+});
+
+describe('advantages multiply, limitations divide', () => {
+    it('raises the active cost with an advantage', () => {
+        const character = build(draft({powers: [blast({name: 'Burst', modifiers: [{xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: []}]})]}));
+
+        // Area Of Effect (8m Radius) is +1/2. 50 x 1.5 = 75 active, and with no limitation the
+        // real cost is the same.
+        expect(priced(character)).toEqual([{label: 'Burst', base: 50, active: 75, real: 75}]);
+    });
+
+    it('lowers the real cost with a limitation, leaving the active cost alone', () => {
+        const character = build(draft({powers: [blast({name: 'Wand', modifiers: [{xmlid: 'FOCUS', option: 'OAF', adders: []}]})]}));
+
+        // Obvious Accessible Focus is -1. The dice are unchanged and so is the active cost —
+        // 50 / (1 + 1) = 25 real. A limitation never makes a power weaker, only cheaper.
+        expect(priced(character)).toEqual([{label: 'Wand', base: 50, active: 50, real: 25}]);
+    });
+
+    it('applies both at once, in the right order', () => {
+        const character = build(
+            draft({
+                powers: [
+                    blast({
+                        name: 'Grenade',
+                        modifiers: [
+                            {xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: []},
+                            {xmlid: 'FOCUS', option: 'OAF', adders: []},
+                        ],
+                    }),
+                ],
+            }),
+        );
+
+        // Advantages apply to the base, limitations to the active: (50 x 1.5) / 2 = 37.5 → 37,
+        // rounded in the player's favour. Doing it the other way round would give 38.
+        expect(priced(character)).toEqual([{label: 'Grenade', base: 50, active: 75, real: 37}]);
+    });
+
+    it("prices a modifier's own adders, which are easy to miss", () => {
+        const bare = build(draft({powers: [blast({modifiers: [{xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: []}]})]}));
+        const selective = build(
+            draft({powers: [blast({modifiers: [{xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: [{xmlid: 'SELECTIVETARGET'}]}]})]}),
+        );
+
+        // Selective is +1/4 on top of the +1/2: 50 x 1.75 = 87.5 → 87. Without nested adders in
+        // the catalogue this would silently stay at 75.
+        expect(bare.powers[0] && priced(bare)[0].active).toBe(75);
+        expect(priced(selective)[0].active).toBe(87);
+    });
+
+    it('reads an advantage and a limitation apart by the sign of the cost, not by a flag', () => {
+        // Nothing in the draft says which is which — `ModifierCalculator` splits on the computed
+        // cost, so a modifier whose option flips its sign lands in the right bucket by itself.
+        expect(modifier('AOE', '6E')?.basecost).toBeGreaterThanOrEqual(0);
+        expect(modifier('FOCUS', '6E')?.options.some((option) => option.basecost < 0)).toBe(true);
+    });
+});
+
+describe('the powers catalogue', () => {
+    it('offers powers and withholds the ones needing a form of their own', () => {
+        const offered = authorable('powers', '6E').map((entry) => entry.xmlid);
+        const notYet = withheld('powers', '6E').map((entry) => entry.xmlid);
+
+        expect(offered).toContain('ENERGYBLAST');
+        expect(offered).toContain('FORCEFIELD');
+        expect(offered.length).toBeGreaterThan(60);
+
+        // Barrier — `FORCEWALL` in the data, in both editions — wants a length/height/width/body
+        // box; Compound Power is a container.
+        expect(notYet).toContain('FORCEWALL');
+        expect(notYet).toContain('COMPOUNDPOWER');
+        // The sense enhancements state no cost of their own — they belong to a sense, not a sheet.
+        expect(notYet).toContain('TELESCOPIC');
+    });
+
+    it('marks powers as modifiable and everything else as not', () => {
+        expect(trait('ENERGYBLAST', 'powers', '6E')?.modifiable).toBe(true);
+        expect(trait('ACROBATICS', 'skills', '6E')?.modifiable).toBe(false);
+    });
+
+    it('offers each edition its own modifiers', () => {
+        expect(modifiers('6E').length).toBeGreaterThan(100);
+        expect(modifiers('6E').map((entry) => entry.xmlid)).toContain('AOE');
+        // De-duplicated, like every other catalogue.
+        const ids = modifiers('5E').map((entry) => entry.xmlid);
+        expect(ids.length).toBe(new Set(ids).size);
+    });
+
+    it("carries a modifier's nested adders", () => {
+        expect(modifier('AOE', '6E')?.adders.map((adder) => adder.xmlid)).toEqual(expect.arrayContaining(['SELECTIVETARGET', 'EXPLOSION']));
+    });
+});
+
+describe('validate — powers', () => {
+    it('rejects a modifier this edition does not define, which would change nothing at all', () => {
+        const bogus = draft({powers: [blast({modifiers: [{xmlid: 'NOT_A_MODIFIER', adders: []}]})]});
+
+        expect(errors(bogus)).toEqual([expect.stringContaining('has no modifier')]);
+
+        // The demonstration: it builds, and the power costs exactly what it did unmodified.
+        expect(priced(build(bogus))[0]).toMatchObject({base: 50, active: 50, real: 50});
+    });
+
+    it('rejects a modifier with no option chosen', () => {
+        expect(errors(draft({powers: [blast({modifiers: [{xmlid: 'FOCUS', adders: []}]})]}))).toEqual([expect.stringContaining('needs one of')]);
+    });
+
+    it('rejects a Resistant Protection with no defences, which would cost points and defend nothing', () => {
+        const naked = draft({powers: [{xmlid: 'FORCEFIELD', name: 'Hollow', input: '', adders: [], levels: 0, modifiers: []}]});
+
+        expect(errors(naked)).toEqual([expect.stringContaining('grants no defence')]);
+    });
+
+    it('warns rather than blocks when the defences are all zero', () => {
+        const zeroed = draft({powers: [{xmlid: 'FORCEFIELD', name: 'Nothing', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 0, ed: 0, mental: 0, power: 0}}]});
+
+        expect(errors(zeroed)).toEqual([]);
+        expect(validate(zeroed).some((problem) => problem.severity === 'warning' && problem.message.includes('no defence'))).toBe(true);
+    });
+
+    it('rejects a power that needs a form of its own rather than offering a broken one', () => {
+        expect(errors(draft({powers: [{xmlid: 'FORCEWALL', name: 'Wall', input: '', adders: [], levels: 4, modifiers: []}]}))).toEqual([
+            expect.stringContaining('form of its own'),
+        ]);
+    });
+});
+
+describe('a power survives storage', () => {
+    const complete = draft({
+        characteristics: {str: 20},
+        powers: [
+            blast({
+                name: 'Grenade',
+                modifiers: [
+                    {xmlid: 'AOE', option: 'RADIUS', levels: 8, adders: [{xmlid: 'SELECTIVETARGET'}]},
+                    {xmlid: 'FOCUS', option: 'OAF', adders: []},
+                ],
+            }),
+            {xmlid: 'FORCEFIELD', name: 'Dense Body', input: '', adders: [], levels: 0, modifiers: [], defense: {pd: 17, ed: 17, mental: 0, power: 0}},
+        ],
+    });
+
+    it('round-trips, modifiers and defences and all', () => {
+        const reopened = parseSource(JSON.parse(JSON.stringify(toSource(complete))))!;
+
+        expect(reopened).toEqual(complete);
+        expect(build(reopened)).toEqual(build(complete));
+    });
+
+    it('counts every power toward the total', () => {
+        const spend = spendOf(build(complete));
+
+        // Grenade: (50 x 1.75) / 2 = 43.75 → 43. Dense Body: 51.
+        expect(spend.traits).toBe(94);
+    });
+
+    it('reads a Phase B source, which had no powers key, as empty', () => {
+        const phaseB = {edition: '6E', name: 'Old', player: '', characteristics: {}, skills: [], perks: [], talents: [], complications: []};
+
+        expect(parseSource(phaseB)).toEqual({...emptyDraft('6E'), name: 'Old'});
+    });
+});

--- a/src/core/authoring/__tests__/traits.test.ts
+++ b/src/core/authoring/__tests__/traits.test.ts
@@ -1,0 +1,273 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Skills, perks and talents (Phase B of docs/CHARACTER_AUTHORING.md).
+ *
+ * Costs and rolls are derived from the HERO rules and stated in the comments; neither legacy nor
+ * `core/random` is an oracle here. What makes these worth writing is that a skill has three ways to
+ * be priced — by characteristic, by familiarity, by a chosen option — and picking the wrong one
+ * does not fail, it just costs nothing.
+ */
+import {authorable, build, catalogue, emptyDraft, isSaveable, parseSource, spendOf, toSource, trait, validate, withheld, type AuthoredCharacter} from 'core/authoring';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const draft = (over: Partial<AuthoredCharacter> = {}): AuthoredCharacter => ({...emptyDraft('6E'), name: 'Probe', ...over});
+const errors = (subject: AuthoredCharacter): string[] =>
+    validate(subject)
+        .filter((problem) => problem.severity === 'error')
+        .map((problem) => problem.message);
+
+/** Every trait in a category, decorated the way the sheet decorates it. */
+const rows = (character: Obj, key: string): Array<{label: string; cost: number; roll: string | null}> =>
+    ((character[key] ?? []) as Obj[]).map((entry) => {
+        const decorated = characterTraitDecorator.decorate(entry, key, () => character);
+
+        return {label: decorated.label(), cost: decorated.realCost(), roll: (decorated.roll()?.roll as string) ?? null};
+    });
+
+describe('the catalogue is what the engine will match against', () => {
+    it('de-duplicates: normalization concatenates entries onto the array they came from', () => {
+        const skills = catalogue('skills', '6E');
+        const ids = skills.map((entry) => entry.xmlid);
+
+        expect(ids.length).toBe(new Set(ids).size);
+    });
+
+    it('derives the xmlid of an entry that sits under its own sub-key', () => {
+        // `knowledgeSkill` in the template, `KNOWLEDGE_SKILL` to the engine. Getting this wrong
+        // produces a catalogue entry no character can ever match.
+        expect(trait('KNOWLEDGE_SKILL', 'skills', '6E')).not.toBeNull();
+        expect(trait('COMBAT_LUCK', 'talents', '6E')).not.toBeNull();
+        expect(trait('CONTACT', 'perks', '6E')).not.toBeNull();
+    });
+
+    it('offers each edition only its own entries', () => {
+        // 6E folded 5E's separate single-action Lightning Reflexes into an option of the one talent.
+        expect(trait('MENTAL_COMBAT_LEVELS', 'skills', '6E')).not.toBeNull();
+        expect(trait('MENTAL_COMBAT_LEVELS', 'skills', '5E')).toBeNull();
+    });
+
+    it('withholds the traits whose decorators read fields no template declares, and says so', () => {
+        const bespoke = withheld('skills', '6E').map((entry) => entry.xmlid);
+
+        expect(bespoke).toContain('WEAPON_FAMILIARITY');
+        expect(bespoke).toContain('TRANSPORT_FAMILIARITY');
+        // Withheld, not hidden: a caller can count them rather than quietly show a shorter list.
+        expect(withheld('skills', '6E').every((entry) => entry.unsupported !== null)).toBe(true);
+        expect(authorable('skills', '6E').every((entry) => entry.unsupported === null)).toBe(true);
+        expect(authorable('skills', '6E').length).toBeGreaterThan(50);
+    });
+});
+
+describe('skills — the three ways one can be priced', () => {
+    it('prices by characteristic, and rolls against it', () => {
+        const character = build(
+            draft({
+                characteristics: {dex: 18},
+                skills: [
+                    {xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 0},
+                    {xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 2},
+                ],
+            }),
+        );
+
+        // 6E Acrobatics is 3 points on DEX, +2 a level. The roll is 9 + DEX/5 = 9 + 3.6 → 13-.
+        expect(rows(character, 'skills')).toEqual([
+            {label: 'Acrobatics', cost: 3, roll: '13-'},
+            {label: 'Acrobatics', cost: 7, roll: '15-'},
+        ]);
+    });
+
+    it('prices a familiarity at a point, rolling a flat 8-', () => {
+        const character = build(draft({characteristics: {dex: 18}, skills: [{xmlid: 'ACROBATICS', input: '', adders: [], familiarity: true}]}));
+
+        // A familiarity is its own purchase, not "the skill with no levels": 1 point, 8- flat,
+        // and deliberately *not* affected by the 18 DEX above.
+        expect(rows(character, 'skills')).toEqual([{label: 'Acrobatics', cost: 1, roll: '8-'}]);
+    });
+
+    it('prices a Language by its fluency, which is an option not a characteristic', () => {
+        const character = build(
+            draft({
+                skills: [
+                    {xmlid: 'LANGUAGES', input: 'French', adders: [], option: 'FLUENT', levels: 0},
+                    {xmlid: 'LANGUAGES', input: 'Mandarin', adders: [], option: 'IDIOMATIC', levels: 0},
+                ],
+            }),
+        );
+
+        // fluent conversation 2, idiomatic 4 — straight off the template's option list.
+        expect(rows(character, 'skills')).toEqual([
+            {label: 'Language: French', cost: 2, roll: null},
+            {label: 'Language: Mandarin', cost: 4, roll: null},
+        ]);
+    });
+
+    it('prices Skill Levels by the breadth chosen, which changes the per-level price', () => {
+        const character = build(
+            draft({
+                skills: [
+                    {xmlid: 'SKILL_LEVELS', input: '', adders: [], option: 'CHARACTERISTIC', levels: 3},
+                    {xmlid: 'SKILL_LEVELS', input: '', adders: [], option: 'RELATED', levels: 3},
+                ],
+            }),
+        );
+
+        // "with a single Skill or Characteristic Roll" is 2/level; "with any three pre-defined
+        // Skills" is 3. Same three levels, different price — which is the whole point of the option.
+        expect(rows(character, 'skills').map((row) => row.cost)).toEqual([6, 9]);
+    });
+
+    it('carries the free text through to the label', () => {
+        const character = build(draft({characteristics: {int: 15}, skills: [{xmlid: 'KNOWLEDGE_SKILL', input: 'The Underworld', adders: [], characteristic: 'INT', levels: 0}]}));
+
+        expect(rows(character, 'skills')).toEqual([{label: 'Knowledge Skill: The Underworld', cost: 3, roll: '12-'}]);
+    });
+});
+
+describe('perks and talents', () => {
+    it("prices a flat perk and talent at the template's own basecost", () => {
+        const character = build(
+            draft({
+                perks: [{xmlid: 'ANONYMITY', input: '', adders: [], levels: 0}],
+                talents: [{xmlid: 'ABSOLUTE_TIME_SENSE', input: '', adders: [], levels: 0}],
+            }),
+        );
+
+        // Both are 3-point buys. They price at 0 unless the trait carries its own basecost —
+        // `CharacterTrait.cost()` reads the trait, never the template.
+        expect(rows(character, 'perks')).toEqual([{label: 'Anonymity', cost: 3, roll: null}]);
+        expect(rows(character, 'talents')).toEqual([{label: 'Absolute Time Sense', cost: 3, roll: null}]);
+    });
+
+    it('prices a levelled perk and talent per level', () => {
+        const character = build(
+            draft({
+                perks: [{xmlid: 'CONTACT', input: 'Police Chief', adders: [], levels: 3}],
+                talents: [{xmlid: 'COMBAT_LUCK', input: '', adders: [], levels: 2}],
+            }),
+        );
+
+        expect(rows(character, 'perks')[0].cost).toBe(3); // Contact: 1 a level
+        expect(rows(character, 'talents')[0].cost).toBe(12); // Combat Luck: 6 a level
+    });
+
+    it('prices a perk with adders through the same adder machinery complications use', () => {
+        const bare = build(draft({perks: [{xmlid: 'CONTACT', input: 'Police Chief', adders: [], levels: 2}]}));
+        const withAdder = build(
+            draft({perks: [{xmlid: 'CONTACT', input: 'Police Chief', adders: [{xmlid: 'USEFUL', option: 'USEFUL'}], levels: 2}]}),
+        );
+
+        // "Contact has useful Skills or resources" is +1. The adder path is shared, so this is the
+        // same code that prices a Psychological Complication's Situation.
+        expect(rows(withAdder, 'perks')[0].cost - rows(bare, 'perks')[0].cost).toBe(1);
+    });
+});
+
+describe('validate — what a skill gets wrong that the engine will not complain about', () => {
+    it('rejects a skill with no characteristic, which would otherwise price at 0', () => {
+        const missing = draft({skills: [{xmlid: 'ACROBATICS', input: '', adders: [], levels: 0}]});
+
+        expect(errors(missing)).toEqual([expect.stringContaining('which characteristic')]);
+
+        // The demonstration: the engine builds it happily and charges nothing for it.
+        const character = build(missing);
+        expect(rows(character, 'skills')).toEqual([{label: 'Acrobatics', cost: 0, roll: null}]);
+    });
+
+    it('rejects a characteristic the skill cannot be based on', () => {
+        expect(errors(draft({skills: [{xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'INT', levels: 0}]}))).toEqual([
+            expect.stringContaining('cannot be based on INT'),
+        ]);
+    });
+
+    it('does not demand a characteristic for a familiarity, which rolls a flat 8-', () => {
+        expect(errors(draft({skills: [{xmlid: 'ACROBATICS', input: '', adders: [], familiarity: true}]}))).toEqual([]);
+    });
+
+    it('rejects a Language with no fluency chosen', () => {
+        expect(errors(draft({skills: [{xmlid: 'LANGUAGES', input: 'French', adders: [], levels: 0}]}))).toEqual([expect.stringContaining('needs one of')]);
+    });
+
+    it('rejects a trait this build cannot render a form for, rather than offering a broken one', () => {
+        expect(errors(draft({skills: [{xmlid: 'WEAPON_FAMILIARITY', input: '', adders: [], levels: 0}]}))).toEqual([expect.stringContaining('form of its own')]);
+    });
+
+    it('rejects familiarity on something that does not offer it', () => {
+        expect(errors(draft({talents: [{xmlid: 'ABSOLUTE_TIME_SENSE', input: '', adders: [], familiarity: true}]}))).toEqual([
+            expect.stringContaining('cannot be taken at familiarity'),
+        ]);
+    });
+
+    it('names the category in the message, so a player knows which list to look in', () => {
+        expect(errors(draft({perks: [{xmlid: 'NOPE', input: '', adders: [], levels: 0}]}))).toEqual([expect.stringContaining('has no perk')]);
+        expect(errors(draft({talents: [{xmlid: 'NOPE', input: '', adders: [], levels: 0}]}))).toEqual([expect.stringContaining('has no talent')]);
+    });
+});
+
+describe('a whole character', () => {
+    const complete = draft({
+        characteristics: {str: 20, dex: 18, int: 15},
+        skills: [
+            {xmlid: 'ACROBATICS', input: '', adders: [], characteristic: 'DEX', levels: 0},
+            {xmlid: 'LANGUAGES', input: 'French', adders: [], option: 'FLUENT', levels: 0},
+        ],
+        perks: [{xmlid: 'ANONYMITY', input: '', adders: [], levels: 0}],
+        talents: [{xmlid: 'COMBAT_LUCK', input: '', adders: [], levels: 2}],
+        complications: [
+            {
+                xmlid: 'PSYCHOLOGICALLIMITATION',
+                input: 'Code Of The Hero',
+                adders: [
+                    {xmlid: 'SITUATION', option: 'COMMON'},
+                    {xmlid: 'INTENSITY', option: 'STRONG'},
+                ],
+            },
+        ],
+    });
+
+    it('validates clean', () => {
+        expect(isSaveable(validate(complete))).toBe(true);
+        expect(errors(complete)).toEqual([]);
+    });
+
+    it('totals what the engine says each part costs', () => {
+        const spend = spendOf(build(complete));
+
+        // STR 10 + DEX 16 + INT 5 = 31 characteristics.
+        expect(spend.characteristics).toBe(31);
+        // Acrobatics 3 + French 2 + Anonymity 3 + Combat Luck 12 = 20.
+        expect(spend.traits).toBe(20);
+        expect(spend.spent).toBe(51);
+        // Complications fund the build rather than being part of it.
+        expect(spend.complications).toBe(15);
+    });
+
+    it('round-trips through storage and rebuilds identically', () => {
+        const reopened = parseSource(JSON.parse(JSON.stringify(toSource(complete))))!;
+
+        expect(reopened).toEqual(complete);
+        expect(build(reopened)).toEqual(build(complete));
+    });
+
+    it('reads a Phase A source, which had no skills/perks/talents keys, as empty', () => {
+        // A schema addition must not lock players out of characters they already saved.
+        const phaseA = {edition: '6E', name: 'Old', player: '', characteristics: {str: 20}, complications: []};
+
+        expect(parseSource(phaseA)).toEqual({...emptyDraft('6E'), name: 'Old', characteristics: {str: 20}});
+    });
+});

--- a/src/core/authoring/__tests__/validate.test.ts
+++ b/src/core/authoring/__tests__/validate.test.ts
@@ -1,0 +1,268 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The validator earns its place by catching what the engine will *not* complain about.
+ *
+ * Each error case below is paired with a demonstration of the silent failure it prevents — the
+ * point is not that `validate` returns a string, it is that without it the character would save
+ * looking correct and costing less than it should.
+ */
+import {build, emit, emptyDraft, isSaveable, validate, type AuthoredCharacter} from 'core/authoring';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const draft = (over: Partial<AuthoredCharacter> = {}): AuthoredCharacter => ({...emptyDraft('6E'), name: 'Probe', ...over});
+const errors = (subject: AuthoredCharacter): string[] => validate(subject).filter((problem) => problem.severity === 'error').map((problem) => problem.message);
+
+describe('validate — the silent-zero trap', () => {
+    const unknownComplication = draft({complications: [{xmlid: 'NOT_A_REAL_COMPLICATION', input: 'Whatever', adders: []}]});
+
+    it('rejects a complication this edition does not define', () => {
+        expect(errors(unknownComplication)).toEqual([expect.stringContaining('has no complication')]);
+        expect(isSaveable(validate(unknownComplication))).toBe(false);
+    });
+
+    it('demonstrates why: the engine prices the same thing at 0 without complaint', () => {
+        const character = build(unknownComplication);
+        const [complication] = character.disadvantages as Obj[];
+
+        // No template resolved...
+        expect(complication.template).toBeUndefined();
+        // ...so it is worth nothing, and nothing threw on the way here. On the sheet this reads as
+        // a complication the player took, funding a 5E build with points that do not exist.
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).cost()).toBe(0);
+    });
+
+    it('rejects a characteristic the edition abolished, which would otherwise throw on build', () => {
+        // 6E deleted COM. `getCharacteristicFields` reads the template entry's definition with no
+        // guard, so this is one of the few inputs that does not fail quietly.
+        expect(errors(draft({characteristics: {com: 20}}))).toEqual([expect.stringContaining('6E has no "COM"')]);
+        expect(errors(draft({edition: '5E', characteristics: {ocv: 8}}))).toEqual([expect.stringContaining('5E has no "OCV"')]);
+    });
+
+    it("accepts each edition's own characteristics", () => {
+        expect(errors(draft({edition: '5E', characteristics: {com: 20, str: 15}})).length).toBe(0);
+        expect(errors(draft({edition: '6E', characteristics: {ocv: 8, str: 15}})).length).toBe(0);
+    });
+});
+
+describe('validate — required adders', () => {
+    it('rejects a Psychological Complication with no Situation or Intensity', () => {
+        // Both are `required: true` in the template. Without them it prices at 0 — legal-looking,
+        // and free.
+        expect(errors(draft({complications: [{xmlid: 'PSYCHOLOGICALLIMITATION', input: 'Code', adders: []}]}))).toEqual([
+            expect.stringContaining('Situation'),
+            expect.stringContaining('Intensity'),
+        ]);
+    });
+
+    it('rejects an option that is not one of the offered ones', () => {
+        expect(
+            errors(
+                draft({
+                    complications: [
+                        {
+                            xmlid: 'PSYCHOLOGICALLIMITATION',
+                            input: 'Code',
+                            adders: [
+                                {xmlid: 'SITUATION', option: 'CATASTROPHIC'},
+                                {xmlid: 'INTENSITY', option: 'STRONG'},
+                            ],
+                        },
+                    ],
+                }),
+            ),
+        ).toEqual([expect.stringContaining('needs one of')]);
+    });
+
+    it('accepts a complete one', () => {
+        expect(
+            errors(
+                draft({
+                    complications: [
+                        {
+                            xmlid: 'PSYCHOLOGICALLIMITATION',
+                            input: 'Code Of The Hero',
+                            adders: [
+                                {xmlid: 'SITUATION', option: 'COMMON'},
+                                {xmlid: 'INTENSITY', option: 'STRONG'},
+                            ],
+                        },
+                    ],
+                }),
+            ),
+        ).toEqual([]);
+    });
+});
+
+describe('validate — Rivalry, whose label reads an adder', () => {
+    // Rivalry declares no `inputlabel`: it is described entirely through adders, and its
+    // `DESCRIPTION` is a free-text one whose optionAlias carries the player's words behind an
+    // opening bracket. `Complication.label()` slices that bracket off.
+    const rivalryWithout = draft({complications: [{xmlid: 'RIVALRY', input: '', adders: []}]});
+
+    it('rejects a Rivalry missing the adders the template marks required', () => {
+        // The template already says `required: true` for all five, so no special-case list is
+        // needed — DESCRIPTION among them.
+        expect(errors(rivalryWithout)).toEqual([
+            expect.stringContaining('Rivalry Situation'),
+            expect.stringContaining('Rivalry Desc.'),
+            expect.stringContaining("Rival's Power"),
+            expect.stringContaining('Fierceness'),
+            expect.stringContaining('Knowledge'),
+        ]);
+    });
+
+    it('rejects a Rivalry whose description is blank, which renders as nothing at all', () => {
+        expect(
+            errors(
+                draft({
+                    complications: [
+                        {
+                            xmlid: 'RIVALRY',
+                            input: '',
+                            adders: [
+                                {xmlid: 'SITUATION', option: 'PROFESSIONAL'},
+                                {xmlid: 'DESCRIPTION', text: '   '},
+                                {xmlid: 'POWER', option: 'AS'},
+                                {xmlid: 'FIERCENESS', option: 'OUTDO'},
+                                {xmlid: 'KNOWLEDGE', option: 'AWARE'},
+                            ],
+                        },
+                    ],
+                }),
+            ),
+        ).toEqual([expect.stringContaining('needs some text')]);
+    });
+
+    it('demonstrates why: rendering it throws, and the sheet turns that into a 0-point row', () => {
+        const character = build(rivalryWithout);
+        const [complication] = character.disadvantages as Obj[];
+
+        // `Complication.label()` does `adderMap.get('DESCRIPTION').optionAlias.slice(1)` unguarded.
+        // characterSheet catches this and emits a stub row — the player sees a complication that
+        // costs nothing and never sees an error.
+        expect(() => characterTraitDecorator.decorate(complication, 'disadvantages', () => character).label()).toThrow();
+    });
+
+    it('labels a complete Rivalry from the description the player typed', () => {
+        const character = build(
+            draft({
+                complications: [
+                    {
+                        xmlid: 'RIVALRY',
+                        input: '',
+                        adders: [
+                            {xmlid: 'SITUATION', option: 'PROFESSIONAL'},
+                            {xmlid: 'DESCRIPTION', text: 'Doctor Destroyer'},
+                            {xmlid: 'POWER', option: 'AS'},
+                            {xmlid: 'FIERCENESS', option: 'OUTDO'},
+                            {xmlid: 'KNOWLEDGE', option: 'AWARE'},
+                        ],
+                    },
+                ],
+            }),
+        );
+        const [complication] = character.disadvantages as Obj[];
+
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).label()).toBe('Rivalry: Doctor Destroyer');
+    });
+});
+
+describe('validate — advice, not obstruction', () => {
+    it('warns about a nameless character but still allows the save', () => {
+        const problems = validate(draft({name: '   '}));
+
+        expect(problems).toContainEqual(expect.objectContaining({severity: 'warning', path: 'name'}));
+        expect(isSaveable(problems)).toBe(true);
+    });
+
+    it('warns when a complication has no input, because the label falls back to its type', () => {
+        const problems = validate(
+            draft({
+                complications: [
+                    {
+                        xmlid: 'PSYCHOLOGICALLIMITATION',
+                        input: '',
+                        adders: [
+                            {xmlid: 'SITUATION', option: 'COMMON'},
+                            {xmlid: 'INTENSITY', option: 'STRONG'},
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        expect(problems.filter((problem) => problem.severity === 'error')).toEqual([]);
+        expect(problems).toContainEqual(expect.objectContaining({severity: 'warning'}));
+
+        // And the claim in that warning is true: no `input`, so no ": …" on the label.
+        const character = build(draft({complications: [{xmlid: 'PSYCHOLOGICALLIMITATION', input: '', adders: [{xmlid: 'SITUATION', option: 'COMMON'}]}]}));
+        const [complication] = character.disadvantages as Obj[];
+        expect(characterTraitDecorator.decorate(complication, 'disadvantages', () => character).label()).not.toContain(':');
+    });
+
+    it('sorts errors ahead of warnings', () => {
+        const problems = validate(draft({name: '', complications: [{xmlid: 'NOPE', input: '', adders: []}]}));
+
+        expect(problems[0].severity).toBe('error');
+        expect(problems[problems.length - 1].severity).toBe('warning');
+    });
+});
+
+describe('validate — a draft it passes is one the engine can build', () => {
+    it('builds every complication the edition offers, when validate is happy with it', () => {
+        // The guarantee worth having: "no errors" means the sheet will render it. Anything that
+        // throws here is a hole in the validator, not a bad test.
+        const complete = draft({
+            characteristics: {str: 20, dex: 18},
+            complications: [
+                {
+                    xmlid: 'HUNTED',
+                    input: 'Arch Enemy',
+                    adders: [
+                        {xmlid: 'APPEARANCE', option: 'EIGHT'},
+                        {xmlid: 'CAPABILITIES', option: 'AS'},
+                        {xmlid: 'MOTIVATION', option: 'HARSH'},
+                    ],
+                },
+                {
+                    xmlid: 'RIVALRY',
+                    input: '',
+                    adders: [
+                        {xmlid: 'SITUATION', option: 'PROFESSIONAL'},
+                        {xmlid: 'DESCRIPTION', text: 'Doctor Destroyer'},
+                        {xmlid: 'POWER', option: 'AS'},
+                        {xmlid: 'FIERCENESS', option: 'OUTDO'},
+                        {xmlid: 'KNOWLEDGE', option: 'AWARE'},
+                    ],
+                },
+                {xmlid: 'UNLUCK', input: '', adders: [], levels: 2},
+            ],
+        });
+
+        expect(errors(complete)).toEqual([]);
+
+        const character = build(complete);
+        for (const complication of character.disadvantages as Obj[]) {
+            const decorated = characterTraitDecorator.decorate(complication, 'disadvantages', () => character);
+            expect(() => decorated.label()).not.toThrow();
+            expect(() => decorated.cost()).not.toThrow();
+        }
+
+        expect(emit(complete)).toBeDefined();
+    });
+});

--- a/src/core/authoring/catalogue.ts
+++ b/src/core/authoring/catalogue.ts
@@ -1,0 +1,234 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What can be authored, read off the rules templates (docs/CHARACTER_AUTHORING.md).
+ *
+ * The `.hdt` entries are not just costs — they are the field definitions HERO Designer builds its
+ * own dialogs from: `display`, `inputlabel`, `option` lists, `adder` lists, `required`,
+ * `mincost`/`maxcost`, `minval`/`maxval`. This module is the one place that reads them, so the UI
+ * renders a form it was told about rather than one somebody transcribed.
+ *
+ * **Nothing here states a cost that the engine will later compute.** An option's `basecost` is
+ * carried through to the emitted trait because that is where the `.hdc` format puts it, but no
+ * total is ever added up here — `spent()` asks the engine. Two sources of truth for a price is
+ * exactly how the legacy `skillsets.json` came to disagree with itself.
+ */
+import {getTemplate} from 'core/templates';
+import type {AuthoringEdition} from './types';
+
+type Obj = Record<string, any>;
+
+/**
+ * The built-in template each edition authors against.
+ *
+ * Superheroic, matching what the generator builds and what the corpus mostly is. The genre
+ * overlays (Heroic, Normal, Automaton…) differ only by which entries they remove, and offering
+ * that choice is a Phase B decision — a draft records its edition, not its genre, so adding it
+ * later is a new field rather than a reinterpretation of an old one.
+ */
+export const TEMPLATE_FOR: Readonly<Record<AuthoringEdition, string>> = {
+    '5E': 'builtIn.Superheroic.hdt',
+    '6E': 'builtIn.Superheroic6E.hdt',
+};
+
+export const templateFor = (edition: AuthoringEdition): string => TEMPLATE_FOR[edition];
+
+const asArray = (value: unknown): Obj[] => (Array.isArray(value) ? (value as Obj[]) : value === null || value === undefined ? [] : [value as Obj]);
+
+/** One choice within an adder that offers a list — "Common", "Very Common". */
+export interface CatalogueOption {
+    readonly xmlid: string;
+    readonly display: string;
+    /** What choosing it costs. Copied onto the emitted adder; never summed here. */
+    readonly basecost: number;
+}
+
+/** An adder the player may (or must) answer on a trait. */
+export interface CatalogueAdder {
+    readonly xmlid: string;
+    readonly display: string;
+    /** The template says the trait is incomplete without it — the validator enforces this. */
+    readonly required: boolean;
+    readonly basecost: number;
+    /** Non-empty when the adder is a pick-one; empty when it is a flat yes/no, levelled, or free text. */
+    readonly options: readonly CatalogueOption[];
+    /**
+     * The adder's "option" is really a text field the player fills in.
+     *
+     * HERO Designer encodes this as a single option whose display is a bare opening bracket: the
+     * stored `optionAlias` becomes `"(" + whatever the player typed`, and the reader strips the
+     * bracket back off — `Complication.label()` literally does `.slice(1)`. There is exactly one
+     * such adder in either edition's data (Rivalry's `DESCRIPTION`), so this is detected from the
+     * data rather than hardcoded, but it is not a general mechanism and should not become one.
+     */
+    readonly freeText: boolean;
+    /** The single option a free-text adder must still name when emitted; null otherwise. */
+    readonly freeTextOption: CatalogueOption | null;
+    /** Present when the adder is bought in levels rather than picked. */
+    readonly levels: LevelRange | null;
+}
+
+/** The bounds a levelled field is allowed to take, straight from the template. */
+export interface LevelRange {
+    readonly min: number;
+    readonly max: number;
+    readonly perLevel: number;
+    readonly label: string;
+}
+
+/** A complication the player may take. */
+export interface CatalogueComplication {
+    readonly xmlid: string;
+    readonly display: string;
+    /** The prompt for the free-text field — "Limitation", "Situation". Null when it takes none. */
+    readonly inputLabel: string | null;
+    readonly definition: string;
+    readonly adders: readonly CatalogueAdder[];
+    readonly levels: LevelRange | null;
+}
+
+const levelRangeOf = (entry: Obj, label: string): LevelRange | null => {
+    if (typeof entry.lvlcost !== 'number' || typeof entry.lvlval !== 'number') {
+        return null;
+    }
+
+    return {
+        min: typeof entry.minval === 'number' ? entry.minval : 0,
+        // `maxval` is usually absent and occasionally 999999999 — both mean "no ceiling worth
+        // showing". A spinner needs *a* number, and one a player could plausibly reach.
+        max: typeof entry.maxval === 'number' && entry.maxval < 1000 ? entry.maxval : 100,
+        perLevel: entry.lvlcost,
+        label: typeof entry.levelslabel === 'string' ? entry.levelslabel : label,
+    };
+};
+
+const optionsOf = (adder: Obj): CatalogueOption[] =>
+    asArray(adder.option).map((option) => ({
+        xmlid: String(option.xmlid),
+        display: String(option.display ?? option.xmlid),
+        basecost: typeof option.basecost === 'number' ? option.basecost : 0,
+    }));
+
+/** The bracket-only option that marks a free-text adder — see {@link CatalogueAdder.freeText}. */
+const FREE_TEXT_MARKER = '(';
+
+const adderOf = (adder: Obj): CatalogueAdder => {
+    const options = optionsOf(adder);
+    const freeText = options.length === 1 && options[0].display.trim() === FREE_TEXT_MARKER;
+
+    return {
+        xmlid: String(adder.xmlid),
+        display: String(adder.display ?? adder.xmlid),
+        required: adder.required === true,
+        basecost: typeof adder.basecost === 'number' ? adder.basecost : 0,
+        // A free-text adder has nothing to pick from, so it offers no options to a chooser.
+        options: freeText ? [] : options,
+        freeText,
+        freeTextOption: freeText ? options[0] : null,
+        levels: levelRangeOf(adder, 'Levels'),
+    };
+};
+
+/**
+ * Every complication this edition defines, in template order.
+ *
+ * `GENERICDISADVANTAGE` is included: it is the escape hatch for a complication the rulebook has no
+ * entry for, and the engine prices it from its adders like any other.
+ */
+export function complications(edition: AuthoringEdition): CatalogueComplication[] {
+    const template = getTemplate(templateFor(edition)) as unknown as Obj;
+
+    return asArray(template.disadvantages?.disad).map((entry) => ({
+        xmlid: String(entry.xmlid),
+        display: String(entry.display ?? entry.xmlid),
+        inputLabel: typeof entry.inputlabel === 'string' ? entry.inputlabel : null,
+        definition: typeof entry.definition === 'string' ? entry.definition : '',
+        adders: asArray(entry.adder).map(adderOf),
+        levels: levelRangeOf(entry, 'Levels'),
+    }));
+}
+
+/** One complication by xmlid, or null when this edition has no such entry. */
+export const complication = (xmlid: string, edition: AuthoringEdition): CatalogueComplication | null =>
+    complications(edition).find((entry) => entry.xmlid === xmlid) ?? null;
+
+/**
+ * The characteristics this edition defines, in the order a sheet reads them.
+ *
+ * Asked of the template rather than hardcoded, for the reason `core/random/characteristics`
+ * documents: a second list of what 6E has would be a copy of the template, free to drift from it.
+ * The editions differ in both directions — COM is 5E-only, OCV/DCV/OMCV/DMCV are 6E-only — and
+ * emitting a characteristic the template lacks is not survivable, so this list is the authority.
+ */
+export interface CatalogueCharacteristic {
+    readonly key: string;
+    readonly name: string;
+    /** What the characteristic is before a point is spent — the floor a spinner starts from. */
+    readonly base: number;
+    /** Points per point of the characteristic. Indicative only; the engine prices the build. */
+    readonly perPoint: number;
+    readonly min: number;
+    readonly max: number;
+    /** True for Running/Swimming/Leaping — shown apart from the primaries. */
+    readonly movement: boolean;
+}
+
+/** Ordered as HERO Designer writes them; see `core/random/characteristics` on why order matters. */
+const CHARACTERISTIC_ORDER = [
+    'str',
+    'dex',
+    'con',
+    'body',
+    'int',
+    'ego',
+    'pre',
+    'com',
+    'ocv',
+    'dcv',
+    'omcv',
+    'dmcv',
+    'spd',
+    'pd',
+    'ed',
+    'rec',
+    'end',
+    'stun',
+    'running',
+    'swimming',
+    'leaping',
+] as const;
+
+const MOVEMENT = new Set(['running', 'swimming', 'leaping']);
+
+export function characteristics(edition: AuthoringEdition): CatalogueCharacteristic[] {
+    const template = getTemplate(templateFor(edition)) as unknown as Obj;
+    const defined = (template.characteristics ?? {}) as Obj;
+
+    return CHARACTERISTIC_ORDER.filter((key) => defined[key] !== undefined).map((key) => {
+        const entry = defined[key] as Obj;
+        const base = typeof entry.base === 'number' ? entry.base : 0;
+
+        return {
+            key,
+            name: String(entry.display ?? key.toUpperCase()),
+            base,
+            perPoint: typeof entry.lvlcost === 'number' && typeof entry.lvlval === 'number' && entry.lvlval !== 0 ? entry.lvlcost / entry.lvlval : 1,
+            // `minval` is the floor in *levels*, so the lowest reachable total is base + minval.
+            min: base + (typeof entry.minval === 'number' ? entry.minval : 0),
+            max: base + (typeof entry.maxval === 'number' && entry.maxval < 10000 ? entry.maxval : 999),
+            movement: MOVEMENT.has(key),
+        };
+    });
+}

--- a/src/core/authoring/catalogue.ts
+++ b/src/core/authoring/catalogue.ts
@@ -17,14 +17,20 @@
  *
  * The `.hdt` entries are not just costs — they are the field definitions HERO Designer builds its
  * own dialogs from: `display`, `inputlabel`, `option` lists, `adder` lists, `required`,
- * `mincost`/`maxcost`, `minval`/`maxval`. This module is the one place that reads them, so the UI
- * renders a form it was told about rather than one somebody transcribed.
+ * `characteristicChoice`, `familiarityroll`, `minval`/`maxval`. This module is the one place that
+ * reads them, so the UI renders a form it was told about rather than one somebody transcribed.
  *
  * **Nothing here states a cost that the engine will later compute.** An option's `basecost` is
  * carried through to the emitted trait because that is where the `.hdc` format puts it, but no
- * total is ever added up here — `spent()` asks the engine. Two sources of truth for a price is
+ * total is ever added up here — `spendOf` asks the engine. Two sources of truth for a price is
  * exactly how the legacy `skillsets.json` came to disagree with itself.
+ *
+ * Entries come from `heroDesignerCharacter.normalizedTemplate`, not from `getTemplate` directly,
+ * because an entry's xmlid is often *derived* from the sub-key it sits under (`knowledgeSkill` →
+ * `KNOWLEDGE_SKILL`). Deriving it here as well is how a catalogue comes to offer a trait the
+ * engine cannot match.
  */
+import {heroDesignerCharacter} from 'core/hero';
 import {getTemplate} from 'core/templates';
 import type {AuthoringEdition} from './types';
 
@@ -35,8 +41,8 @@ type Obj = Record<string, any>;
  *
  * Superheroic, matching what the generator builds and what the corpus mostly is. The genre
  * overlays (Heroic, Normal, Automaton…) differ only by which entries they remove, and offering
- * that choice is a Phase B decision — a draft records its edition, not its genre, so adding it
- * later is a new field rather than a reinterpretation of an old one.
+ * that choice is a later decision — a draft records its edition, not its genre, so adding it later
+ * is a new field rather than a reinterpretation of an old one.
  */
 export const TEMPLATE_FOR: Readonly<Record<AuthoringEdition, string>> = {
     '5E': 'builtIn.Superheroic.hdt',
@@ -47,12 +53,46 @@ export const templateFor = (edition: AuthoringEdition): string => TEMPLATE_FOR[e
 
 const asArray = (value: unknown): Obj[] => (Array.isArray(value) ? (value as Obj[]) : value === null || value === undefined ? [] : [value as Obj]);
 
-/** One choice within an adder that offers a list — "Common", "Very Common". */
+/** The trait categories that can be authored, and the sub-key each keeps its entries under. */
+export const AUTHORABLE_CATEGORIES = {
+    skills: 'skill',
+    perks: 'perk',
+    talents: 'talent',
+    disadvantages: 'disad',
+} as const;
+
+export type AuthorableCategory = keyof typeof AUTHORABLE_CATEGORIES;
+
+/** One choice within an option list — "Common", "completely fluent", "with all Agility Skills". */
 export interface CatalogueOption {
     readonly xmlid: string;
     readonly display: string;
-    /** What choosing it costs. Copied onto the emitted adder; never summed here. */
+    /** What choosing it costs. Copied onto the emitted trait/adder; never summed here. */
     readonly basecost: number;
+    /**
+     * Present when picking this option changes the *per-level* price rather than a flat cost.
+     *
+     * Skill Levels are the case: "with any three pre-defined Skills" is 3 points a level where
+     * "with a single Skill or Characteristic Roll" is 2. The engine reads it off the template;
+     * it rides here so a form can say what a choice costs before it is made.
+     */
+    readonly perLevel: number | null;
+}
+
+/** The bounds a levelled field is allowed to take, straight from the template. */
+export interface LevelRange {
+    readonly min: number;
+    readonly max: number;
+    readonly perLevel: number;
+    readonly label: string;
+}
+
+/** A characteristic a skill may be based on, and what it costs on that characteristic. */
+export interface CatalogueCharacteristicChoice {
+    /** `DEX`, `INT`, or `GENERAL` for a skill that rolls a flat 11-. */
+    readonly characteristic: string;
+    readonly basecost: number;
+    readonly perLevel: number;
 }
 
 /** An adder the player may (or must) answer on a trait. */
@@ -80,45 +120,100 @@ export interface CatalogueAdder {
     readonly levels: LevelRange | null;
 }
 
-/** The bounds a levelled field is allowed to take, straight from the template. */
-export interface LevelRange {
-    readonly min: number;
-    readonly max: number;
-    readonly perLevel: number;
-    readonly label: string;
-}
+/**
+ * Why a trait cannot be offered yet.
+ *
+ * Stated rather than silently filtered, because a catalogue that quietly drops part of the
+ * rulebook reads to a player as "the app doesn't have Weapon Familiarity" rather than "not yet".
+ * The UI counts them; see the "no silent caps" note in docs/CHARACTER_AUTHORING.md.
+ */
+export type Unsupported =
+    /** Its decorator reads fields the template never declares, so a generic form cannot fill them. */
+    | 'bespoke'
+    /** Nothing in the entry says what it costs — it is priced entirely by its own decorator. */
+    | 'unpriced';
 
-/** A complication the player may take. */
-export interface CatalogueComplication {
+/**
+ * Traits whose decorators read fields no template declares.
+ *
+ * Each is a `core/traits` class with its own idea of what the trait carries — Transport
+ * Familiarity's nested adder tree, Weapon Familiarity's category/member split, Autofire Skills'
+ * per-skill list. A generic form cannot produce those, and producing them *badly* is worse than
+ * not offering them: the engine prices a malformed trait at 0 rather than refusing it.
+ *
+ * The custom* entries are here for the opposite reason — they are deliberately open-ended, and
+ * what they need is a bespoke "write your own" form rather than a generated one.
+ *
+ * Shrinking this list is the substance of a later phase, one decorator at a time.
+ */
+const BESPOKE = new Set([
+    'AUTOFIRE_SKILLS',
+    'CRAMMING',
+    'CUSTOMSKILL',
+    'CUSTOMPERK',
+    'CUSTOMTALENT',
+    'DEFENSE_MANEUVER',
+    'RAPID_ATTACK_HTH',
+    'TRANSPORT_FAMILIARITY',
+    'TWO_WEAPON_FIGHTING_HTH',
+    'WEAPON_FAMILIARITY',
+    // 5E spells two of them differently for the same decorators.
+    'RAPID_ATTACK',
+    'TWO_WEAPON_FIGHTING',
+]);
+
+/** A trait the player may take, with everything a form needs to render it. */
+export interface CatalogueTrait {
+    readonly category: AuthorableCategory;
     readonly xmlid: string;
     readonly display: string;
-    /** The prompt for the free-text field — "Limitation", "Situation". Null when it takes none. */
-    readonly inputLabel: string | null;
     readonly definition: string;
+    /** The prompt for the free-text field — "Language", "Contact Name". Null when it takes none. */
+    readonly inputLabel: string | null;
+    /**
+     * What the entry costs before levels, options and adders.
+     *
+     * Emitted onto the trait, because that is where a real `.hdc` puts it and where
+     * `CharacterTrait.cost()` reads it — the template is consulted for *per-level* prices but never
+     * for the base. A trait emitted without it prices at 0 and still renders, which is how a
+     * 3-point Talent becomes free.
+     */
+    readonly basecost: number;
+    /** The characteristics this skill may roll against; empty for anything that is not a skill roll. */
+    readonly characteristics: readonly CatalogueCharacteristicChoice[];
+    /** The entry's own pick-one list — a Language's fluency, a Skill Level's breadth. */
+    readonly options: readonly CatalogueOption[];
     readonly adders: readonly CatalogueAdder[];
     readonly levels: LevelRange | null;
+    /** Non-null when the skill may be taken at familiarity — an 8- roll for a reduced cost. */
+    readonly familiarity: {readonly roll: number; readonly cost: number} | null;
+    /** Null when it can be authored; otherwise why not. */
+    readonly unsupported: Unsupported | null;
 }
 
 const levelRangeOf = (entry: Obj, label: string): LevelRange | null => {
-    if (typeof entry.lvlcost !== 'number' || typeof entry.lvlval !== 'number') {
+    if (typeof entry.lvlcost !== 'number' || typeof entry.lvlval !== 'number' || entry.lvlval === 0) {
         return null;
     }
 
     return {
-        min: typeof entry.minval === 'number' ? entry.minval : 0,
+        // `minval` is occasionally deeply negative (Skill Levels declare -99). A floor of 0 is what
+        // a player can actually buy; a negative number of levels is not a thing a form can offer.
+        min: typeof entry.minval === 'number' && entry.minval > 0 ? entry.minval : 0,
         // `maxval` is usually absent and occasionally 999999999 — both mean "no ceiling worth
         // showing". A spinner needs *a* number, and one a player could plausibly reach.
         max: typeof entry.maxval === 'number' && entry.maxval < 1000 ? entry.maxval : 100,
-        perLevel: entry.lvlcost,
+        perLevel: entry.lvlcost / entry.lvlval,
         label: typeof entry.levelslabel === 'string' ? entry.levelslabel : label,
     };
 };
 
-const optionsOf = (adder: Obj): CatalogueOption[] =>
-    asArray(adder.option).map((option) => ({
+const optionsOf = (entry: Obj): CatalogueOption[] =>
+    asArray(entry.option).map((option) => ({
         xmlid: String(option.xmlid),
         display: String(option.display ?? option.xmlid),
         basecost: typeof option.basecost === 'number' ? option.basecost : 0,
+        perLevel: typeof option.lvlcost === 'number' && typeof option.lvlval === 'number' && option.lvlval !== 0 ? option.lvlcost / option.lvlval : null,
     }));
 
 /** The bracket-only option that marks a free-text adder — see {@link CatalogueAdder.freeText}. */
@@ -142,27 +237,85 @@ const adderOf = (adder: Obj): CatalogueAdder => {
 };
 
 /**
- * Every complication this edition defines, in template order.
+ * The characteristics a skill may be bought against.
  *
- * `GENERICDISADVANTAGE` is included: it is the escape hatch for a complication the rulebook has no
- * entry for, and the engine prices it from its adders like any other.
+ * `characteristicChoice.item` is one object or an array of them, each naming a characteristic with
+ * its own base and per-level cost — Acrobatics is DEX only, but a Knowledge Skill can be INT or
+ * GENERAL, and the two are not the same price.
  */
-export function complications(edition: AuthoringEdition): CatalogueComplication[] {
-    const template = getTemplate(templateFor(edition)) as unknown as Obj;
-
-    return asArray(template.disadvantages?.disad).map((entry) => ({
-        xmlid: String(entry.xmlid),
-        display: String(entry.display ?? entry.xmlid),
-        inputLabel: typeof entry.inputlabel === 'string' ? entry.inputlabel : null,
-        definition: typeof entry.definition === 'string' ? entry.definition : '',
-        adders: asArray(entry.adder).map(adderOf),
-        levels: levelRangeOf(entry, 'Levels'),
+const characteristicChoicesOf = (entry: Obj): CatalogueCharacteristicChoice[] =>
+    asArray(entry.characteristicChoice?.item).map((item) => ({
+        characteristic: String(item.characteristic),
+        basecost: typeof item.basecost === 'number' ? item.basecost : 0,
+        perLevel: typeof item.lvlcost === 'number' && typeof item.lvlval === 'number' && item.lvlval !== 0 ? item.lvlcost / item.lvlval : 0,
     }));
+
+function traitOf(entry: Obj, category: AuthorableCategory): CatalogueTrait {
+    const xmlid = String(entry.xmlid);
+    const choices = characteristicChoicesOf(entry);
+    const options = optionsOf(entry);
+    const adders = asArray(entry.adder).map(adderOf);
+    const levels = levelRangeOf(entry, 'Levels');
+    const priced = typeof entry.basecost === 'number' || levels !== null || choices.length > 0 || options.length > 0 || adders.length > 0;
+
+    return {
+        category,
+        xmlid,
+        display: String(entry.display ?? xmlid),
+        definition: typeof entry.definition === 'string' ? entry.definition : '',
+        inputLabel: typeof entry.inputlabel === 'string' ? entry.inputlabel : null,
+        basecost: typeof entry.basecost === 'number' ? entry.basecost : 0,
+        characteristics: choices,
+        options,
+        adders,
+        levels,
+        familiarity: typeof entry.familiarityroll === 'number' && typeof entry.familiaritycost === 'number' ? {roll: entry.familiarityroll, cost: entry.familiaritycost} : null,
+        unsupported: BESPOKE.has(xmlid) ? 'bespoke' : priced ? null : 'unpriced',
+    };
 }
 
+/**
+ * Every entry a category defines in an edition, de-duplicated and in template order.
+ *
+ * De-duplication is not optional: `normalizedTemplate` concatenates the entries it collected onto
+ * the array they partly came from, so each plainly-declared skill appears twice.
+ */
+export function catalogue(category: AuthorableCategory, edition: AuthoringEdition): CatalogueTrait[] {
+    const template = heroDesignerCharacter.normalizedTemplate(templateFor(edition));
+    const seen = new Set<string>();
+    const traits: CatalogueTrait[] = [];
+
+    for (const entry of asArray(template[category]?.[AUTHORABLE_CATEGORIES[category]])) {
+        const xmlid = String(entry.xmlid);
+
+        if (seen.has(xmlid)) {
+            continue;
+        }
+
+        seen.add(xmlid);
+        traits.push(traitOf(entry, category));
+    }
+
+    return traits;
+}
+
+/** The entries a player may actually take — everything the generic form can render. */
+export const authorable = (category: AuthorableCategory, edition: AuthoringEdition): CatalogueTrait[] =>
+    catalogue(category, edition).filter((entry) => entry.unsupported === null);
+
+/** The entries deliberately withheld, so a caller can say how many rather than quietly drop them. */
+export const withheld = (category: AuthorableCategory, edition: AuthoringEdition): CatalogueTrait[] =>
+    catalogue(category, edition).filter((entry) => entry.unsupported !== null);
+
+/** One entry by xmlid, or null when this edition has no such thing. */
+export const trait = (xmlid: string, category: AuthorableCategory, edition: AuthoringEdition): CatalogueTrait | null =>
+    catalogue(category, edition).find((entry) => entry.xmlid === xmlid) ?? null;
+
+/** Complications, kept as its own name because the UI and the rules both call them that. */
+export const complications = (edition: AuthoringEdition): CatalogueTrait[] => catalogue('disadvantages', edition);
+
 /** One complication by xmlid, or null when this edition has no such entry. */
-export const complication = (xmlid: string, edition: AuthoringEdition): CatalogueComplication | null =>
-    complications(edition).find((entry) => entry.xmlid === xmlid) ?? null;
+export const complication = (xmlid: string, edition: AuthoringEdition): CatalogueTrait | null => trait(xmlid, 'disadvantages', edition);
 
 /**
  * The characteristics this edition defines, in the order a sheet reads them.
@@ -213,6 +366,8 @@ const CHARACTERISTIC_ORDER = [
 const MOVEMENT = new Set(['running', 'swimming', 'leaping']);
 
 export function characteristics(edition: AuthoringEdition): CatalogueCharacteristic[] {
+    // The un-normalized template on purpose: normalization moves Running/Swimming/Leaping into
+    // `powers`, and this list wants the characteristics where a character sheet keeps them.
     const template = getTemplate(templateFor(edition)) as unknown as Obj;
     const defined = (template.characteristics ?? {}) as Obj;
 

--- a/src/core/authoring/catalogue.ts
+++ b/src/core/authoring/catalogue.ts
@@ -59,6 +59,7 @@ export const AUTHORABLE_CATEGORIES = {
     perks: 'perk',
     talents: 'talent',
     powers: 'power',
+    martialArts: 'maneuver',
     disadvantages: 'disad',
 } as const;
 
@@ -169,6 +170,8 @@ const BESPOKE_POWERS = ['FORCEWALL', 'DUPLICATION', 'ENDURANCERESERVE', 'FLASH',
 
 const BESPOKE = new Set([
     ...BESPOKE_POWERS,
+    // Weapon Element wants a list of weapons the style covers, which no template describes.
+    'WEAPON_ELEMENT',
     'AUTOFIRE_SKILLS',
     'CRAMMING',
     'CUSTOMSKILL',
@@ -217,6 +220,26 @@ const FIELD_GROUPS: Readonly<Record<string, FieldGroup>> = {
     },
 };
 
+/**
+ * A maneuver's combat line, as the template states it.
+ *
+ * Copied onto the emitted trait rather than left in the template, because `Maneuver` reads all of
+ * it off the *trait* — a real `.hdc` writes it out per maneuver and the decorator was written
+ * against that. A maneuver emitted without them renders with no OCV, no DCV and no effect.
+ */
+export interface ManeuverProfile {
+    readonly ocv: number;
+    readonly dcv: number;
+    readonly dc: number;
+    readonly phase: string;
+    readonly effect: string;
+    readonly weaponEffect: string;
+    readonly category: string;
+    readonly addStr: boolean;
+    readonly activeCost: number;
+    readonly killing: boolean;
+}
+
 /** A trait the player may take, with everything a form needs to render it. */
 export interface CatalogueTrait {
     readonly category: AuthorableCategory;
@@ -244,6 +267,8 @@ export interface CatalogueTrait {
     readonly familiarity: {readonly roll: number; readonly cost: number} | null;
     /** Non-null when the trait needs fields no template describes — see {@link FieldGroup}. */
     readonly fieldGroup: FieldGroup | null;
+    /** Non-null for a martial maneuver: the combat line the sheet prints. */
+    readonly maneuver: ManeuverProfile | null;
     /** True when the power may carry advantages and limitations. */
     readonly modifiable: boolean;
     /** Null when it can be authored; otherwise why not. */
@@ -317,6 +342,26 @@ const characteristicChoicesOf = (entry: Obj): CatalogueCharacteristicChoice[] =>
         perLevel: typeof item.lvlcost === 'number' && typeof item.lvlval === 'number' && item.lvlval !== 0 ? item.lvlcost / item.lvlval : 0,
     }));
 
+const maneuverProfileOf = (entry: Obj): ManeuverProfile | null => {
+    if (typeof entry.phase !== 'string' || typeof entry.effect !== 'string') {
+        return null;
+    }
+
+    return {
+        ocv: typeof entry.ocv === 'number' ? entry.ocv : 0,
+        dcv: typeof entry.dcv === 'number' ? entry.dcv : 0,
+        dc: typeof entry.dc === 'number' ? entry.dc : 0,
+        phase: entry.phase,
+        effect: entry.effect,
+        weaponEffect: typeof entry.weaponeffect === 'string' ? entry.weaponeffect : '',
+        category: typeof entry.category === 'string' ? entry.category : '',
+        // The template writes "Y"/"N" here where a parsed `.hdc` carries a boolean.
+        addStr: entry.addstr === true || entry.addstr === 'Y',
+        activeCost: typeof entry.activecost === 'number' ? entry.activecost : 0,
+        killing: entry.killing === true,
+    };
+};
+
 function traitOf(entry: Obj, category: AuthorableCategory): CatalogueTrait {
     const xmlid = String(entry.xmlid);
     const choices = characteristicChoicesOf(entry);
@@ -338,6 +383,7 @@ function traitOf(entry: Obj, category: AuthorableCategory): CatalogueTrait {
         levels,
         familiarity: typeof entry.familiarityroll === 'number' && typeof entry.familiaritycost === 'number' ? {roll: entry.familiarityroll, cost: entry.familiaritycost} : null,
         fieldGroup: FIELD_GROUPS[xmlid] ?? null,
+        maneuver: category === 'martialArts' ? maneuverProfileOf(entry) : null,
         // Only powers take advantages and limitations. A skill with an advantage is not a thing.
         modifiable: category === 'powers',
         unsupported: BESPOKE.has(xmlid) ? 'bespoke' : priced ? null : 'unpriced',

--- a/src/core/authoring/catalogue.ts
+++ b/src/core/authoring/catalogue.ts
@@ -58,6 +58,7 @@ export const AUTHORABLE_CATEGORIES = {
     skills: 'skill',
     perks: 'perk',
     talents: 'talent',
+    powers: 'power',
     disadvantages: 'disad',
 } as const;
 
@@ -118,6 +119,14 @@ export interface CatalogueAdder {
     readonly freeTextOption: CatalogueOption | null;
     /** Present when the adder is bought in levels rather than picked. */
     readonly levels: LevelRange | null;
+    /**
+     * Adders of its own — one level deep, which is all the data has.
+     *
+     * Area Of Effect is the everyday case: it is a modifier with a Radius/Cone/Line option *and*
+     * Selective/Nonselective/Explosion adders that change what it costs. Without these an AOE
+     * prices as its bare option and quietly comes out cheap.
+     */
+    readonly adders: readonly CatalogueAdder[];
 }
 
 /**
@@ -146,7 +155,20 @@ export type Unsupported =
  *
  * Shrinking this list is the substance of a later phase, one decorator at a time.
  */
+/**
+ * Powers whose decorators read level fields the template never declares, and which therefore
+ * cannot be filled in by a generated form.
+ *
+ * `FORCEFIELD` is deliberately *not* here: it is the most-taken defensive power in the corpus and
+ * granting it a declared field group (see {@link FIELD_GROUPS}) was cheaper than withholding it.
+ * The rest need the same treatment one at a time — Barrier (`FORCEWALL` in both editions' data)
+ * wants a length/height/width/body box, Duplication a number and a point total, Endurance Reserve
+ * a REC.
+ */
+const BESPOKE_POWERS = ['FORCEWALL', 'DUPLICATION', 'ENDURANCERESERVE', 'FLASH', 'COMPOUNDPOWER', 'MULTIFORM', 'SUMMON', 'VPP'];
+
 const BESPOKE = new Set([
+    ...BESPOKE_POWERS,
     'AUTOFIRE_SKILLS',
     'CRAMMING',
     'CUSTOMSKILL',
@@ -161,6 +183,39 @@ const BESPOKE = new Set([
     'RAPID_ATTACK',
     'TWO_WEAPON_FIGHTING',
 ]);
+
+/**
+ * Extra numeric fields a specific trait needs that no template declares.
+ *
+ * The escape hatch for the per-power long tail, kept deliberately small and explicit. Each entry
+ * is a field the engine reads straight off the trait, with no template to describe it — so the
+ * only options are to declare it here, or to withhold the power and say why.
+ */
+export interface FieldGroup {
+    readonly kind: 'defense';
+    readonly label: string;
+    readonly fields: ReadonlyArray<{readonly key: 'pd' | 'ed' | 'mental' | 'power'; readonly label: string}>;
+}
+
+/**
+ * Resistant Protection's four-way defence split.
+ *
+ * `getResistantDefense` and the unusual-defense queries read `pdlevels`/`edlevels`/`mdlevels`/
+ * `powdlevels` directly off the trait. A Resistant Protection emitted without them costs full
+ * price and grants no defence at all — priced correctly, silently useless.
+ */
+const FIELD_GROUPS: Readonly<Record<string, FieldGroup>> = {
+    FORCEFIELD: {
+        kind: 'defense',
+        label: 'Points of resistant defence',
+        fields: [
+            {key: 'pd', label: 'rPD'},
+            {key: 'ed', label: 'rED'},
+            {key: 'mental', label: 'Mental'},
+            {key: 'power', label: 'Power'},
+        ],
+    },
+};
 
 /** A trait the player may take, with everything a form needs to render it. */
 export interface CatalogueTrait {
@@ -187,6 +242,10 @@ export interface CatalogueTrait {
     readonly levels: LevelRange | null;
     /** Non-null when the skill may be taken at familiarity — an 8- roll for a reduced cost. */
     readonly familiarity: {readonly roll: number; readonly cost: number} | null;
+    /** Non-null when the trait needs fields no template describes — see {@link FieldGroup}. */
+    readonly fieldGroup: FieldGroup | null;
+    /** True when the power may carry advantages and limitations. */
+    readonly modifiable: boolean;
     /** Null when it can be authored; otherwise why not. */
     readonly unsupported: Unsupported | null;
 }
@@ -219,7 +278,12 @@ const optionsOf = (entry: Obj): CatalogueOption[] =>
 /** The bracket-only option that marks a free-text adder — see {@link CatalogueAdder.freeText}. */
 const FREE_TEXT_MARKER = '(';
 
-const adderOf = (adder: Obj): CatalogueAdder => {
+/**
+ * `depth` guards the one level of nesting the data has. It is never passed positionally from a
+ * `.map` — `Array.prototype.map` hands the index in as the second argument, which silently reads
+ * as "you are already nested" for every entry but the first.
+ */
+const adderOf = (adder: Obj, depth: 0 | 1 = 0): CatalogueAdder => {
     const options = optionsOf(adder);
     const freeText = options.length === 1 && options[0].display.trim() === FREE_TEXT_MARKER;
 
@@ -233,6 +297,9 @@ const adderOf = (adder: Obj): CatalogueAdder => {
         freeText,
         freeTextOption: freeText ? options[0] : null,
         levels: levelRangeOf(adder, 'Levels'),
+        // One level only. The data never nests further, and a form that recursed arbitrarily would
+        // be describing a shape the rules do not have.
+        adders: depth === 1 ? [] : asArray(adder.adder).map((nested) => adderOf(nested, 1)),
     };
 };
 
@@ -254,7 +321,7 @@ function traitOf(entry: Obj, category: AuthorableCategory): CatalogueTrait {
     const xmlid = String(entry.xmlid);
     const choices = characteristicChoicesOf(entry);
     const options = optionsOf(entry);
-    const adders = asArray(entry.adder).map(adderOf);
+    const adders = asArray(entry.adder).map((adder) => adderOf(adder));
     const levels = levelRangeOf(entry, 'Levels');
     const priced = typeof entry.basecost === 'number' || levels !== null || choices.length > 0 || options.length > 0 || adders.length > 0;
 
@@ -270,6 +337,9 @@ function traitOf(entry: Obj, category: AuthorableCategory): CatalogueTrait {
         adders,
         levels,
         familiarity: typeof entry.familiarityroll === 'number' && typeof entry.familiaritycost === 'number' ? {roll: entry.familiarityroll, cost: entry.familiaritycost} : null,
+        fieldGroup: FIELD_GROUPS[xmlid] ?? null,
+        // Only powers take advantages and limitations. A skill with an advantage is not a thing.
+        modifiable: category === 'powers',
         unsupported: BESPOKE.has(xmlid) ? 'bespoke' : priced ? null : 'unpriced',
     };
 }
@@ -310,6 +380,31 @@ export const withheld = (category: AuthorableCategory, edition: AuthoringEdition
 /** One entry by xmlid, or null when this edition has no such thing. */
 export const trait = (xmlid: string, category: AuthorableCategory, edition: AuthoringEdition): CatalogueTrait | null =>
     catalogue(category, edition).find((entry) => entry.xmlid === xmlid) ?? null;
+
+/**
+ * The advantages and limitations that may be put on a power.
+ *
+ * One flat list rather than two, because which is which is not a property of the modifier — it is
+ * the sign of what it ends up costing, and an option can flip it (Limited Power is a limitation;
+ * some of its options are worth less than others). `ModifierCalculator` splits them on the
+ * computed cost for exactly that reason, and so should anything showing them.
+ */
+export function modifiers(edition: AuthoringEdition): CatalogueAdder[] {
+    const template = heroDesignerCharacter.normalizedTemplate(templateFor(edition));
+    const seen = new Set<string>();
+
+    return asArray(template.modifiers?.modifier)
+        .filter((entry) => {
+            const xmlid = String(entry.xmlid);
+
+            return seen.has(xmlid) ? false : (seen.add(xmlid), true);
+        })
+        .map((entry) => adderOf(entry));
+}
+
+/** One modifier by xmlid, or null when this edition has no such thing. */
+export const modifier = (xmlid: string, edition: AuthoringEdition): CatalogueAdder | null =>
+    modifiers(edition).find((entry) => entry.xmlid === xmlid) ?? null;
 
 /** Complications, kept as its own name because the UI and the rules both call them that. */
 export const complications = (edition: AuthoringEdition): CatalogueTrait[] => catalogue('disadvantages', edition);

--- a/src/core/authoring/emit.ts
+++ b/src/core/authoring/emit.ts
@@ -38,7 +38,7 @@ import type {ParsedCharacter} from 'core/hero';
 import {getTemplate} from 'core/templates';
 import {heroDesignerCharacter} from 'core/hero';
 import {modifier, templateFor, trait, type AuthorableCategory, type CatalogueAdder} from './catalogue';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredFramework, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
 
 type Obj = Record<string, any>;
 
@@ -60,6 +60,19 @@ const ID_BASE: Readonly<Record<string, number>> = {
 
 /** Modifier ids sit in their own block, keyed off the power they hang from. */
 const MODIFIER_ID_BASE = 7000;
+
+/** Framework containers and their slots, far enough from the rest not to collide. */
+const FRAMEWORK_ID_BASE = 9000;
+
+/**
+ * How far apart framework blocks are placed, in both id and position.
+ *
+ * Position matters: `populateTrait` attaches a slot by looking its `parentid` up in the list built
+ * so far, so a container has to be *processed* before its own slots. Since H2 that ordering is the
+ * numeric sort on `position`, so a container simply needs a lower position than everything in it.
+ * Before H2 it could not have worked at all — see docs/KNOWN_DEVIATIONS.md.
+ */
+const FRAMEWORK_STRIDE = 100;
 
 /**
  * Insertion order is load-bearing: `populateMovementAndCharacteristics` walks the object in key
@@ -257,6 +270,54 @@ function emitPower(authored: AuthoredPower, position: number, edition: Authoring
     };
 }
 
+/**
+ * A framework: its container, and its slots parented to it.
+ *
+ * The container is `GENERIC_OBJECT` — the framework's identity is the sub-key it is emitted under,
+ * not its xmlid, which is why {@link FrameworkKind}'s strings are spelled the way the format
+ * spells them. `populateTrait` gives any `GENERIC_OBJECT` `type: 'list'`, and
+ * `normalizeCharacterItems` copies the sub-key onto it as `originalType`; the slot decorators then
+ * match on that.
+ */
+function emitFramework(framework: AuthoredFramework, index: number, edition: AuthoringEdition): {container: Obj; slots: Obj[]} {
+    const id = FRAMEWORK_ID_BASE + index * FRAMEWORK_STRIDE;
+    const position = index * FRAMEWORK_STRIDE;
+
+    const container: Obj = {
+        xmlid: 'GENERIC_OBJECT',
+        id,
+        alias: FRAMEWORK_ALIAS[framework.kind],
+        name: framework.name.trim() === '' ? null : framework.name.trim(),
+        position,
+        multiplier: 1,
+        notes: null,
+        // A Variable Power Pool states its size in `levels`; the other two in `basecost`. That is
+        // the format's choice, and `VariablePowerPool.cost()` reads `levels` accordingly.
+        basecost: framework.kind === 'vpp' ? 0 : framework.reserve,
+        levels: framework.kind === 'vpp' ? framework.reserve : 0,
+        modifier: framework.modifiers.map((entry, order) => emitModifier(entry, id + order, edition)),
+    };
+
+    const slots = framework.slots.map((slot, order) => ({
+        ...emitPower(slot, position + 1 + order, edition),
+        id: id + 1 + order,
+        parentid: id,
+        // Fixed slots only, for now: the variable kind's divisor is unreachable in the engine —
+        // see H13 in docs/KNOWN_DEVIATIONS.md — so offering it would price a variable slot as a
+        // fixed one and say nothing.
+        ultraSlot: true,
+    }));
+
+    return {container, slots};
+}
+
+/** The alias HERO Designer writes on each kind of container. Printed by the sheet as-is. */
+const FRAMEWORK_ALIAS: Readonly<Record<AuthoredFramework['kind'], string>> = {
+    multipower: 'Multipower',
+    elementalControl: 'Elemental Control',
+    vpp: 'Variable Power Pool',
+};
+
 /** A `ParsedCharacter` at the given characteristic *levels* — the shape the engine consumes. */
 function parsedFrom(draft: AuthoredCharacter, levels: Record<string, number>): ParsedCharacter {
     const template = templateFor(draft.edition);
@@ -290,10 +351,30 @@ function parsedFrom(draft: AuthoredCharacter, levels: Record<string, number>): P
         perks: {perk: draft.perks.map((entry, index) => emitTrait(entry, 'perks', index, draft.edition))},
         talents: {talent: draft.talents.map((entry, index) => emitTrait(entry, 'talents', index, draft.edition))},
         martialarts: {},
-        powers: {power: draft.powers.map((entry, index) => emitPower(entry, index, draft.edition))},
+        powers: emitPowers(draft),
         equipment: {},
         disadvantages: {disad: draft.complications.map((entry, index) => emitTrait(entry, 'disadvantages', index, draft.edition))},
     } as unknown as ParsedCharacter;
+}
+
+/**
+ * The `powers` block: standalone powers under `power`, each framework under its own sub-key.
+ *
+ * Containers of the same kind collapse into an array, which is what the XML parser produces for
+ * repeated elements and what `normalizeCharacterItem` already knows how to walk.
+ */
+function emitPowers(draft: AuthoredCharacter): Obj {
+    const powers: Obj = {power: draft.powers.map((entry, index) => emitPower(entry, index, draft.edition))};
+
+    draft.frameworks.forEach((framework, index) => {
+        const {container, slots} = emitFramework(framework, index, draft.edition);
+        const existing = powers[framework.kind];
+
+        powers[framework.kind] = existing === undefined ? container : Array.isArray(existing) ? [...existing, container] : [existing, container];
+        powers.power.push(...slots);
+    });
+
+    return powers;
 }
 
 const totalOf = (character: Obj, key: string): number =>

--- a/src/core/authoring/emit.ts
+++ b/src/core/authoring/emit.ts
@@ -1,0 +1,249 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Turn an {@link AuthoredCharacter} into the `ParsedCharacter` the engine reads
+ * (docs/CHARACTER_AUTHORING.md).
+ *
+ * The engine was written to consume the output of an XML parser, and it relies on that parser's
+ * habits. Four of them are not optional, and each cost a debugging session to find:
+ *
+ *  1. **Every trait category key must be present.** `populateTrait` guards `null` but not
+ *     `undefined`, so a missing `perks` throws `Cannot read properties of undefined`. The `.hdc`
+ *     parser always emits all seven; so does this.
+ *  2. **`name` must be `null`, not absent.** `xml2js` is configured `emptyTag: null`, so an empty
+ *     `NAME=""` arrives as `null` and the label code reads it as "no name". Omit the key entirely
+ *     and the label renders the literal string `"undefined (Acrobatics)"`.
+ *  3. **`alias` is author-supplied.** The engine prints it and never derives it from the template,
+ *     so it is copied from the template's `display` here. Same for an adder's `optionAlias`.
+ *  4. **Ids must be stable and unique.** They are what `parentid` resolves against and what the
+ *     golden master's canonical ordering sorts by. They are derived from position, not from a
+ *     counter or a clock, so emitting the same draft twice gives the same document.
+ *
+ * Pure: same draft in, same `ParsedCharacter` out, every time. That is what makes an authored
+ * character re-openable — the stored source rebuilds byte-for-byte what was saved.
+ */
+import type {ParsedCharacter} from 'core/hero';
+import {getTemplate} from 'core/templates';
+import {heroDesignerCharacter} from 'core/hero';
+import {complication, templateFor, type CatalogueAdder} from './catalogue';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredComplication, AuthoringEdition} from './types';
+
+type Obj = Record<string, any>;
+
+/**
+ * Id blocks, one per category, so a complication and a power can never collide.
+ *
+ * Deliberately small and readable rather than timestamp-shaped like HERO Designer's own. Nothing
+ * reads meaning from an id — it only has to be unique within the character and stable across
+ * emits.
+ */
+const ID_BASE: Readonly<Record<string, number>> = {
+    characteristics: 1000,
+    disadvantages: 5000,
+};
+
+/**
+ * Insertion order is load-bearing: `populateMovementAndCharacteristics` walks the object in key
+ * order and 5E's figured characteristics read the *already populated* primaries. The template's
+ * own key order is alphabetical, which would put `ed` before `ego` and feed the figured maths an
+ * unpopulated primary. See `core/random/characteristics`, which learned this first.
+ */
+const PRIMARY = ['str', 'dex', 'con', 'body', 'int', 'ego', 'pre', 'com'] as const;
+const COMBAT = ['ocv', 'dcv', 'omcv', 'dmcv'] as const;
+const DERIVED = ['pd', 'ed', 'spd', 'rec', 'end', 'stun'] as const;
+const MOVEMENT = ['running', 'swimming', 'leaping'] as const;
+const CHARACTERISTIC_ORDER = [...PRIMARY, ...COMBAT, ...DERIVED, ...MOVEMENT] as const;
+
+const definedBy = (template: string): ReadonlySet<string> =>
+    new Set(Object.keys((getTemplate(template) as unknown as {characteristics?: Obj}).characteristics ?? {}));
+
+const characteristicEntry = (key: string, levels: number, position: number): Obj => ({
+    xmlid: key.toUpperCase(),
+    id: ID_BASE.characteristics + position,
+    alias: key.toUpperCase(),
+    levels,
+    basecost: 0,
+    position,
+    multiplier: 1,
+    name: null,
+    affectsPrimary: true,
+    affectsTotal: true,
+    notes: null,
+});
+
+/** The `.hdc` boilerplate every emitted adder carries, so the data says only what the player chose. */
+const ADDER_DEFAULTS: Obj = {basecost: 0, levels: 0, position: -1, multiplier: 1, name: null, notes: null};
+
+/**
+ * One adder, priced and labelled from the template.
+ *
+ * The chosen option's `basecost` is copied onto the adder because that is where the `.hdc` format
+ * carries it and where `totalAdders` reads it. It is copied at emit time rather than stored on the
+ * draft so a template correction re-prices old drafts instead of preserving a stale number.
+ */
+function emitAdder(chosen: AuthoredAdder, catalogue: CatalogueAdder | undefined): Obj {
+    const base = {
+        ...ADDER_DEFAULTS,
+        xmlid: chosen.xmlid,
+        alias: catalogue?.display ?? chosen.xmlid,
+        basecost: catalogue?.basecost ?? 0,
+        ...(chosen.levels === undefined ? {} : {levels: chosen.levels}),
+    };
+
+    // A free-text adder still names its single option, but its `optionAlias` carries the player's
+    // words behind an opening bracket — which is why the reader slices the first character off.
+    // See CatalogueAdder.freeText; Rivalry's description is the only one in either edition.
+    if (catalogue?.freeText === true && catalogue.freeTextOption !== null) {
+        return {
+            ...base,
+            basecost: catalogue.freeTextOption.basecost,
+            option: catalogue.freeTextOption.xmlid,
+            optionid: catalogue.freeTextOption.xmlid,
+            optionAlias: `(${chosen.text ?? ''}`,
+        };
+    }
+
+    const option = catalogue?.options.find((candidate) => candidate.xmlid === chosen.option);
+
+    return option === undefined
+        ? base
+        : {
+              ...base,
+              basecost: option.basecost,
+              option: option.xmlid,
+              optionid: option.xmlid,
+              // Read by the writeup, and by RIVALRY's label. A missing optionAlias there throws,
+              // and the sheet degrades the row to a cost-0 stub rather than showing an error.
+              optionAlias: option.display,
+          };
+}
+
+const DISADVANTAGE_DEFAULTS: Obj = {
+    basecost: 0,
+    levels: 0,
+    multiplier: 1,
+    name: null,
+    notes: null,
+    affectsPrimary: true,
+    affectsTotal: true,
+};
+
+function emitComplication(authored: AuthoredComplication, position: number, edition: AuthoringEdition): Obj {
+    const catalogue = complication(authored.xmlid, edition);
+
+    return {
+        ...DISADVANTAGE_DEFAULTS,
+        xmlid: authored.xmlid,
+        id: ID_BASE.disadvantages + position,
+        alias: catalogue?.display ?? authored.xmlid,
+        position,
+        // `input` drives the sheet label ("Psychological: Code Of The Hero"). The engine keys on
+        // the property *existing*, so an unanswered one is omitted rather than sent as ''.
+        ...(authored.input.trim() === '' ? {} : {input: authored.input.trim()}),
+        ...(authored.levels === undefined ? {} : {levels: authored.levels}),
+        adder: authored.adders.map((adder) =>
+            emitAdder(
+                adder,
+                catalogue?.adders.find((candidate) => candidate.xmlid === adder.xmlid),
+            ),
+        ),
+    };
+}
+
+/** A `ParsedCharacter` at the given characteristic *levels* — the shape the engine consumes. */
+function parsedFrom(draft: AuthoredCharacter, levels: Record<string, number>): ParsedCharacter {
+    const template = templateFor(draft.edition);
+    const defined = definedBy(template);
+    const characteristics: Obj = {};
+    let position = 0;
+
+    for (const key of CHARACTERISTIC_ORDER) {
+        if (defined.has(key)) {
+            characteristics[key] = characteristicEntry(key, levels[key] ?? 0, position);
+            position += 1;
+        }
+    }
+
+    return {
+        version: 6,
+        template,
+        characterInfo: {
+            characterName: draft.name,
+            playerName: draft.player,
+            alternateIdentities: '',
+            height: '',
+            weight: '',
+            campaignName: '',
+            genre: '',
+            gm: '',
+        },
+        characteristics,
+        // All seven present, every time — `populateTrait` throws on `undefined`, not on `null`.
+        skills: {},
+        perks: {},
+        talents: {},
+        martialarts: {},
+        powers: {},
+        equipment: {},
+        disadvantages: {
+            disad: draft.complications.map((entry, index) => emitComplication(entry, index, draft.edition)),
+        },
+    } as unknown as ParsedCharacter;
+}
+
+const totalOf = (character: Obj, key: string): number =>
+    (character.characteristics as Obj[]).find((entry) => String(entry.shortName).toLowerCase() === key)?.value ?? 0;
+
+const has = (character: Obj, key: string): boolean =>
+    (character.characteristics as Obj[]).some((entry) => String(entry.shortName).toLowerCase() === key);
+
+/**
+ * Emit the engine's input for a draft.
+ *
+ * A draft states characteristics as **totals** — what a player reads off a sheet — but the `.hdc`
+ * stores *levels bought above base*, and in 5E the base itself is figured from other
+ * characteristics (ED from CON, STUN from BODY+STR+CON, and so on). Rather than reimplement that,
+ * the draft is emitted at zero, priced by the engine, and the levels read back as
+ * `target − whatever the engine says base is`. `value = levels + <base and figured terms>` holds
+ * for every characteristic whatever its formula, so one probe settles all of them.
+ *
+ * Two passes because the figured characteristics read the primaries: pass one settles the
+ * primaries, pass two reads the figured bases those imply. 6E figures nothing, so its second pass
+ * is a no-op — one code path rather than an edition branch.
+ */
+export function emit(draft: AuthoredCharacter): ParsedCharacter {
+    const levels: Record<string, number> = {};
+    const probe = (): Obj => heroDesignerCharacter.getCharacter(parsedFrom(draft, levels)) as unknown as Obj;
+
+    const settle = (keys: readonly string[], character: Obj): void => {
+        for (const key of keys) {
+            const target = draft.characteristics[key];
+
+            if (target === undefined || !has(character, key)) {
+                continue;
+            }
+
+            levels[key] = target - totalOf(character, key);
+        }
+    };
+
+    settle([...PRIMARY, ...COMBAT, ...MOVEMENT], probe());
+    settle(DERIVED, probe());
+
+    return parsedFrom(draft, levels);
+}
+
+/** Emit and price in one step — the document the app stores and the sheet renders. */
+export const build = (draft: AuthoredCharacter): Obj => heroDesignerCharacter.getCharacter(emit(draft)) as unknown as Obj;

--- a/src/core/authoring/emit.ts
+++ b/src/core/authoring/emit.ts
@@ -69,12 +69,20 @@ const FRAMEWORK_ID_BASE = 9000;
 /**
  * How far apart framework blocks are placed, in both id and position.
  *
- * Position matters: `populateTrait` attaches a slot by looking its `parentid` up in the list built
- * so far, so a container has to be *processed* before its own slots. Since H2 that ordering is the
- * numeric sort on `position`, so a container simply needs a lower position than everything in it.
- * Before H2 it could not have worked at all — see docs/KNOWN_DEVIATIONS.md.
+ * Position matters twice. `populateTrait` attaches a slot by looking its `parentid` up in the list
+ * built so far, so a container has to be *processed* before its own slots — since H2 that ordering
+ * is the numeric sort on `position`, so a container needs a lower position than everything in it.
+ * Before H2 it could not have worked at all; see docs/KNOWN_DEVIATIONS.md.
+ *
+ * And position is the sheet's display order, which is why frameworks start well above the
+ * standalone powers rather than at zero. Sharing the range put a Multipower at position 0
+ * alongside the first standalone power, so a framework rendered *between* two loose powers and its
+ * slots' positions collided with theirs.
  */
 const FRAMEWORK_STRIDE = 100;
+
+/** Frameworks begin here, past any plausible number of standalone powers. */
+const FRAMEWORK_POSITION_BASE = 1000;
 
 /**
  * Insertion order is load-bearing: `populateMovementAndCharacteristics` walks the object in key
@@ -323,7 +331,7 @@ function emitManeuver(authored: AuthoredTrait, position: number, edition: Author
  */
 function emitFramework(framework: AuthoredFramework, index: number, edition: AuthoringEdition): {container: Obj; slots: Obj[]} {
     const id = FRAMEWORK_ID_BASE + index * FRAMEWORK_STRIDE;
-    const position = index * FRAMEWORK_STRIDE;
+    const position = FRAMEWORK_POSITION_BASE + index * FRAMEWORK_STRIDE;
 
     const container: Obj = {
         xmlid: 'GENERIC_OBJECT',

--- a/src/core/authoring/emit.ts
+++ b/src/core/authoring/emit.ts
@@ -56,6 +56,8 @@ const ID_BASE: Readonly<Record<string, number>> = {
     talents: 4000,
     disadvantages: 5000,
     powers: 6000,
+    martialArts: 10000,
+    equipment: 11000,
 };
 
 /** Modifier ids sit in their own block, keyed off the power they hang from. */
@@ -271,6 +273,46 @@ function emitPower(authored: AuthoredPower, position: number, edition: Authoring
 }
 
 /**
+ * A martial maneuver.
+ *
+ * Emitted with `xmlid: 'MANEUVER'` and a `display`, exactly as HERO Designer writes it —
+ * `normalizeCharacterItems` then derives the real xmlid from the display (`Basic Strike` →
+ * `BASIC_STRIKE`). Deriving it here instead would put that rule in two places, and the engine's
+ * copy is the one the template lookup uses.
+ *
+ * The combat line is copied onto the trait because `Maneuver` reads every part of it off the
+ * trait, not off the template — a real `.hdc` writes it out per maneuver. Without it the sheet
+ * shows a maneuver with no OCV, no DCV and no effect, priced correctly.
+ */
+function emitManeuver(authored: AuthoredTrait, position: number, edition: AuthoringEdition): Obj {
+    const catalogue = trait(authored.xmlid, 'martialArts', edition);
+    const profile = catalogue?.maneuver;
+
+    return {
+        ...emitTrait(authored, 'martialArts', position, edition),
+        xmlid: 'MANEUVER',
+        display: catalogue?.display ?? authored.xmlid,
+        ...(profile === undefined || profile === null
+            ? {}
+            : {
+                  category: profile.category,
+                  ocv: profile.ocv,
+                  dcv: profile.dcv,
+                  dc: profile.dc,
+                  phase: profile.phase,
+                  effect: profile.effect,
+                  weaponeffect: profile.weaponEffect,
+                  addstr: profile.addStr,
+                  activecost: profile.activeCost,
+                  useweapon: false,
+                  damagetype: 0,
+                  maxstr: 0,
+                  strmult: 1,
+              }),
+    };
+}
+
+/**
  * A framework: its container, and its slots parented to it.
  *
  * The container is `GENERIC_OBJECT` — the framework's identity is the sub-key it is emitted under,
@@ -350,9 +392,11 @@ function parsedFrom(draft: AuthoredCharacter, levels: Record<string, number>): P
         skills: {skill: draft.skills.map((entry, index) => emitTrait(entry, 'skills', index, draft.edition))},
         perks: {perk: draft.perks.map((entry, index) => emitTrait(entry, 'perks', index, draft.edition))},
         talents: {talent: draft.talents.map((entry, index) => emitTrait(entry, 'talents', index, draft.edition))},
-        martialarts: {},
+        martialarts: {maneuver: draft.martialArts.map((entry, index) => emitManeuver(entry, index, draft.edition))},
         powers: emitPowers(draft),
-        equipment: {},
+        // Equipment resolves against the *powers* templates — `populateTrait` is called with
+        // `('equipment', 'powers', 'power')` — so an item is emitted exactly as a power is.
+        equipment: {power: draft.equipment.map((entry, index) => ({...emitPower(entry, index, draft.edition), id: ID_BASE.equipment + index}))},
         disadvantages: {disad: draft.complications.map((entry, index) => emitTrait(entry, 'disadvantages', index, draft.edition))},
     } as unknown as ParsedCharacter;
 }

--- a/src/core/authoring/emit.ts
+++ b/src/core/authoring/emit.ts
@@ -37,8 +37,8 @@
 import type {ParsedCharacter} from 'core/hero';
 import {getTemplate} from 'core/templates';
 import {heroDesignerCharacter} from 'core/hero';
-import {templateFor, trait, type AuthorableCategory, type CatalogueAdder} from './catalogue';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredTrait, AuthoringEdition} from './types';
+import {modifier, templateFor, trait, type AuthorableCategory, type CatalogueAdder} from './catalogue';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
 
 type Obj = Record<string, any>;
 
@@ -55,7 +55,11 @@ const ID_BASE: Readonly<Record<string, number>> = {
     perks: 3000,
     talents: 4000,
     disadvantages: 5000,
+    powers: 6000,
 };
+
+/** Modifier ids sit in their own block, keyed off the power they hang from. */
+const MODIFIER_ID_BASE = 7000;
 
 /**
  * Insertion order is load-bearing: `populateMovementAndCharacteristics` walks the object in key
@@ -135,7 +139,6 @@ function emitAdder(chosen: AuthoredAdder, catalogue: CatalogueAdder | undefined)
 
 const TRAIT_DEFAULTS: Obj = {
     multiplier: 1,
-    name: null,
     notes: null,
     affectsPrimary: true,
     affectsTotal: true,
@@ -162,6 +165,8 @@ function emitTrait(authored: AuthoredTrait, category: AuthorableCategory, positi
         id: ID_BASE[category] + position,
         alias: catalogue?.display ?? authored.xmlid,
         position,
+        // Null, never absent — an absent `name` renders the literal string "undefined (Blast)".
+        name: authored.name === undefined || authored.name.trim() === '' ? null : authored.name.trim(),
         // From the template, because that is where a real `.hdc` gets it. `CharacterTrait.cost()`
         // reads the *trait's* basecost and never the template's, so a 3-point Talent emitted
         // without it costs nothing and still renders — the silent-zero trap, from the inside.
@@ -184,6 +189,71 @@ function emitTrait(authored: AuthoredTrait, category: AuthorableCategory, positi
                 catalogue?.adders.find((candidate) => candidate.xmlid === adder.xmlid),
             ),
         ),
+    };
+}
+
+/**
+ * One advantage or limitation, priced and labelled from the modifiers catalogue.
+ *
+ * `alias` and `optionAlias` are what the writeup prints — the engine reads them and never derives
+ * them — and `template` is attached by `getCharacter` itself, matching on xmlid, so nothing here
+ * has to.
+ */
+function emitModifier(authored: AuthoredModifier, position: number, edition: AuthoringEdition): Obj {
+    const catalogue = modifier(authored.xmlid, edition);
+    const option = catalogue?.options.find((candidate) => candidate.xmlid === authored.option);
+
+    return {
+        xmlid: authored.xmlid,
+        id: MODIFIER_ID_BASE + position,
+        alias: catalogue?.display ?? authored.xmlid,
+        basecost: option?.basecost ?? catalogue?.basecost ?? 0,
+        levels: authored.levels ?? 0,
+        position: -1,
+        multiplier: 1,
+        name: null,
+        notes: null,
+        ...(catalogue?.freeText === true && catalogue.freeTextOption !== null
+            ? {option: catalogue.freeTextOption.xmlid, optionid: catalogue.freeTextOption.xmlid, optionAlias: `(${authored.text ?? ''}`}
+            : option === undefined
+              ? {}
+              : {option: option.xmlid, optionid: option.xmlid, optionAlias: option.display}),
+        // A modifier's own adders — Area Of Effect's Selective, Explosion, Mobile.
+        adder: authored.adders.map((adder) =>
+            emitAdder(
+                adder,
+                catalogue?.adders.find((candidate) => candidate.xmlid === adder.xmlid),
+            ),
+        ),
+    };
+}
+
+/**
+ * A power: a trait, plus its modifiers and any field group it declares.
+ *
+ * The defence split is the one place a number is *derived* rather than asked for. A `.hdc` carries
+ * both the split and a `levels` total, and every character in the corpus has the total equal to
+ * the sum — so `levels` comes from the four rather than being a fifth thing to keep in step.
+ */
+function emitPower(authored: AuthoredPower, position: number, edition: AuthoringEdition): Obj {
+    const catalogue = trait(authored.xmlid, 'powers', edition);
+    const base = emitTrait(authored, 'powers', position, edition);
+
+    const defense =
+        catalogue?.fieldGroup?.kind === 'defense' && authored.defense !== undefined
+            ? {
+                  pdlevels: authored.defense.pd,
+                  edlevels: authored.defense.ed,
+                  mdlevels: authored.defense.mental,
+                  powdlevels: authored.defense.power,
+                  levels: authored.defense.pd + authored.defense.ed + authored.defense.mental + authored.defense.power,
+              }
+            : {};
+
+    return {
+        ...base,
+        ...defense,
+        modifier: authored.modifiers.map((entry, index) => emitModifier(entry, position * 20 + index, edition)),
     };
 }
 
@@ -220,7 +290,7 @@ function parsedFrom(draft: AuthoredCharacter, levels: Record<string, number>): P
         perks: {perk: draft.perks.map((entry, index) => emitTrait(entry, 'perks', index, draft.edition))},
         talents: {talent: draft.talents.map((entry, index) => emitTrait(entry, 'talents', index, draft.edition))},
         martialarts: {},
-        powers: {},
+        powers: {power: draft.powers.map((entry, index) => emitPower(entry, index, draft.edition))},
         equipment: {},
         disadvantages: {disad: draft.complications.map((entry, index) => emitTrait(entry, 'disadvantages', index, draft.edition))},
     } as unknown as ParsedCharacter;

--- a/src/core/authoring/emit.ts
+++ b/src/core/authoring/emit.ts
@@ -37,8 +37,8 @@
 import type {ParsedCharacter} from 'core/hero';
 import {getTemplate} from 'core/templates';
 import {heroDesignerCharacter} from 'core/hero';
-import {complication, templateFor, type CatalogueAdder} from './catalogue';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredComplication, AuthoringEdition} from './types';
+import {templateFor, trait, type AuthorableCategory, type CatalogueAdder} from './catalogue';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredTrait, AuthoringEdition} from './types';
 
 type Obj = Record<string, any>;
 
@@ -51,6 +51,9 @@ type Obj = Record<string, any>;
  */
 const ID_BASE: Readonly<Record<string, number>> = {
     characteristics: 1000,
+    skills: 2000,
+    perks: 3000,
+    talents: 4000,
     disadvantages: 5000,
 };
 
@@ -130,9 +133,7 @@ function emitAdder(chosen: AuthoredAdder, catalogue: CatalogueAdder | undefined)
           };
 }
 
-const DISADVANTAGE_DEFAULTS: Obj = {
-    basecost: 0,
-    levels: 0,
+const TRAIT_DEFAULTS: Obj = {
     multiplier: 1,
     name: null,
     notes: null,
@@ -140,19 +141,43 @@ const DISADVANTAGE_DEFAULTS: Obj = {
     affectsTotal: true,
 };
 
-function emitComplication(authored: AuthoredComplication, position: number, edition: AuthoringEdition): Obj {
-    const catalogue = complication(authored.xmlid, edition);
+/**
+ * One trait — skill, perk, talent or complication — in the shape the engine reads.
+ *
+ * All four go through here because the `.hdc` format makes no structural distinction between them:
+ * an xmlid, optional free text, an optional pick-one, levels, and adders. What differs is which of
+ * those the template declares, and the catalogue already answers that.
+ *
+ * **`levels` is always emitted, and always a number.** `Roll` computes a skill roll as
+ * `base + trait.levels`, unguarded — an absent `levels` makes that `NaN` and the sheet prints
+ * "NaN-" rather than failing. Most other numeric fields can be left out; this one cannot.
+ */
+function emitTrait(authored: AuthoredTrait, category: AuthorableCategory, position: number, edition: AuthoringEdition): Obj {
+    const catalogue = trait(authored.xmlid, category, edition);
+    const option = catalogue?.options.find((candidate) => candidate.xmlid === authored.option);
 
     return {
-        ...DISADVANTAGE_DEFAULTS,
+        ...TRAIT_DEFAULTS,
         xmlid: authored.xmlid,
-        id: ID_BASE.disadvantages + position,
+        id: ID_BASE[category] + position,
         alias: catalogue?.display ?? authored.xmlid,
         position,
-        // `input` drives the sheet label ("Psychological: Code Of The Hero"). The engine keys on
-        // the property *existing*, so an unanswered one is omitted rather than sent as ''.
+        // From the template, because that is where a real `.hdc` gets it. `CharacterTrait.cost()`
+        // reads the *trait's* basecost and never the template's, so a 3-point Talent emitted
+        // without it costs nothing and still renders — the silent-zero trap, from the inside.
+        basecost: catalogue?.basecost ?? 0,
+        levels: authored.levels ?? 0,
+        // `input` drives the sheet label ("Psychological: Code Of The Hero", "Language: French").
+        // The engine keys on the property *existing*, so an unanswered one is omitted rather than
+        // sent as an empty string.
         ...(authored.input.trim() === '' ? {} : {input: authored.input.trim()}),
-        ...(authored.levels === undefined ? {} : {levels: authored.levels}),
+        // `Skill.cost()` reads `characteristic` to find its price in the template's
+        // characteristicChoice, and `Roll` reads it to find what the skill rolls against.
+        ...(authored.characteristic === undefined ? {} : {characteristic: authored.characteristic}),
+        // Truthiness is what the decorators test, so an unticked box is omitted rather than false —
+        // matching a real `.hdc`, where FAMILIARITY="No" parses to the boolean.
+        ...(authored.familiarity === true ? {familiarity: true} : {}),
+        ...(option === undefined ? {} : {option: option.xmlid, optionid: option.xmlid, optionAlias: option.display}),
         adder: authored.adders.map((adder) =>
             emitAdder(
                 adder,
@@ -191,15 +216,13 @@ function parsedFrom(draft: AuthoredCharacter, levels: Record<string, number>): P
         },
         characteristics,
         // All seven present, every time — `populateTrait` throws on `undefined`, not on `null`.
-        skills: {},
-        perks: {},
-        talents: {},
+        skills: {skill: draft.skills.map((entry, index) => emitTrait(entry, 'skills', index, draft.edition))},
+        perks: {perk: draft.perks.map((entry, index) => emitTrait(entry, 'perks', index, draft.edition))},
+        talents: {talent: draft.talents.map((entry, index) => emitTrait(entry, 'talents', index, draft.edition))},
         martialarts: {},
         powers: {},
         equipment: {},
-        disadvantages: {
-            disad: draft.complications.map((entry, index) => emitComplication(entry, index, draft.edition)),
-        },
+        disadvantages: {disad: draft.complications.map((entry, index) => emitTrait(entry, 'disadvantages', index, draft.edition))},
     } as unknown as ParsedCharacter;
 }
 

--- a/src/core/authoring/index.ts
+++ b/src/core/authoring/index.ts
@@ -1,0 +1,27 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Authoring a character in the app (docs/CHARACTER_AUTHORING.md).
+ *
+ * Pure core, no RN: a draft goes in, a priced `ParsedCharacter` comes out, and the app stores the
+ * draft beside the document so the character can be re-opened. The same discipline as
+ * `core/random` — and for the same reason, `core/random` is not an oracle for it.
+ */
+export * from './types';
+export * from './catalogue';
+export * from './emit';
+export * from './spend';
+export * from './validate';
+export * from './source';

--- a/src/core/authoring/source.ts
+++ b/src/core/authoring/source.ts
@@ -25,7 +25,17 @@
  * edit it does not.
  */
 import type {StoredSource} from 'core/ports';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredFramework, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition, FrameworkKind} from './types';
+import {DEFAULT_BUDGET} from './types';
+import type {
+    AuthoredAdder,
+    AuthoredCharacter,
+    AuthoredFramework,
+    AuthoredModifier,
+    AuthoredPower,
+    AuthoredTrait,
+    AuthoringEdition,
+    FrameworkKind,
+} from './types';
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -245,6 +255,13 @@ function parseFrameworks(value: unknown): AuthoredFramework[] | null {
     return frameworks;
 }
 
+const isBudget = (value: unknown): value is {base: number; complicationLimit: number} =>
+    isObject(value) &&
+    typeof value.base === 'number' &&
+    Number.isInteger(value.base) &&
+    typeof value.complicationLimit === 'number' &&
+    Number.isInteger(value.complicationLimit);
+
 /**
  * A stored source as a draft, or null when it is not one this build understands.
  *
@@ -275,8 +292,24 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
     const martialArts = parseTraits(source.martialArts ?? []);
     const equipment = parsePowers(source.equipment ?? []);
     const frameworks = parseFrameworks(source.frameworks ?? []);
+    // Sources written before the allowance was pickable have no budget and read as the default —
+    // which is the level they were in fact built to, since it was the only one on offer.
+    const budget = source.budget === undefined ? DEFAULT_BUDGET[source.edition] : source.budget;
 
-    if (skills === null || perks === null || talents === null || complications === null || powers === null || martialArts === null || equipment === null || frameworks === null) {
+    if (!isBudget(budget)) {
+        return null;
+    }
+
+    if (
+        skills === null ||
+        perks === null ||
+        talents === null ||
+        complications === null ||
+        powers === null ||
+        martialArts === null ||
+        equipment === null ||
+        frameworks === null
+    ) {
         return null;
     }
 
@@ -284,6 +317,7 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
         edition: source.edition,
         name: asString(source.name),
         player: asString(source.player),
+        budget: {base: budget.base, complicationLimit: budget.complicationLimit},
         characteristics,
         skills,
         perks,
@@ -320,6 +354,7 @@ export const toSource = (draft: AuthoredCharacter): StoredSource => ({
     edition: draft.edition,
     name: draft.name,
     player: draft.player,
+    budget: {...draft.budget},
     characteristics: {...draft.characteristics},
     skills: draft.skills.map(traitToSource),
     perks: draft.perks.map(traitToSource),

--- a/src/core/authoring/source.ts
+++ b/src/core/authoring/source.ts
@@ -272,9 +272,11 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
     const talents = parseTraits(source.talents ?? []);
     const complications = parseTraits(source.complications ?? []);
     const powers = parsePowers(source.powers ?? []);
+    const martialArts = parseTraits(source.martialArts ?? []);
+    const equipment = parsePowers(source.equipment ?? []);
     const frameworks = parseFrameworks(source.frameworks ?? []);
 
-    if (skills === null || perks === null || talents === null || complications === null || powers === null || frameworks === null) {
+    if (skills === null || perks === null || talents === null || complications === null || powers === null || martialArts === null || equipment === null || frameworks === null) {
         return null;
     }
 
@@ -287,6 +289,8 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
         perks,
         talents,
         powers,
+        martialArts,
+        equipment,
         frameworks,
         complications,
     };
@@ -321,6 +325,8 @@ export const toSource = (draft: AuthoredCharacter): StoredSource => ({
     perks: draft.perks.map(traitToSource),
     talents: draft.talents.map(traitToSource),
     powers: draft.powers.map(powerToSource),
+    martialArts: draft.martialArts.map(traitToSource),
+    equipment: draft.equipment.map(powerToSource),
     frameworks: draft.frameworks.map((framework) => ({
         kind: framework.kind,
         name: framework.name,

--- a/src/core/authoring/source.ts
+++ b/src/core/authoring/source.ts
@@ -1,0 +1,160 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Reading a stored draft back (docs/CHARACTER_AUTHORING.md).
+ *
+ * The mirror of `core/random`'s `parseRecipe`, and it fails the same way on purpose: a source it
+ * cannot make sense of returns `null`, and the character simply stops being editable. It still
+ * opens and still renders, because the sheet reads the *document* — the stored source only governs
+ * whether the editor can be entered.
+ *
+ * That matters because a draft outlives the build that wrote it. Rejecting the whole character
+ * because one field went missing would make a schema change destroy players' work; refusing to
+ * edit it does not.
+ */
+import type {StoredSource} from 'core/ports';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredComplication, AuthoringEdition} from './types';
+
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isEdition = (value: unknown): value is AuthoringEdition => value === '5E' || value === '6E';
+
+const asString = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+/** Characteristic totals: every value must be a finite whole number, or the map is not a map. */
+function parseCharacteristics(value: unknown): Readonly<Record<string, number>> | null {
+    if (!isObject(value)) {
+        return null;
+    }
+
+    const characteristics: Record<string, number> = {};
+
+    for (const [key, total] of Object.entries(value)) {
+        if (typeof total !== 'number' || !Number.isFinite(total) || !Number.isInteger(total)) {
+            return null;
+        }
+
+        characteristics[key] = total;
+    }
+
+    return characteristics;
+}
+
+function parseAdder(value: unknown): AuthoredAdder | null {
+    if (!isObject(value) || typeof value.xmlid !== 'string') {
+        return null;
+    }
+
+    const {option, levels} = value;
+
+    if (option !== undefined && typeof option !== 'string') {
+        return null;
+    }
+
+    if (levels !== undefined && (typeof levels !== 'number' || !Number.isInteger(levels))) {
+        return null;
+    }
+
+    return {
+        xmlid: value.xmlid,
+        ...(option === undefined ? {} : {option}),
+        ...(levels === undefined ? {} : {levels}),
+    };
+}
+
+function parseComplication(value: unknown): AuthoredComplication | null {
+    if (!isObject(value) || typeof value.xmlid !== 'string' || !Array.isArray(value.adders)) {
+        return null;
+    }
+
+    const adders: AuthoredAdder[] = [];
+
+    for (const entry of value.adders) {
+        const adder = parseAdder(entry);
+
+        if (adder === null) {
+            return null;
+        }
+
+        adders.push(adder);
+    }
+
+    const {levels} = value;
+
+    if (levels !== undefined && (typeof levels !== 'number' || !Number.isInteger(levels))) {
+        return null;
+    }
+
+    return {
+        xmlid: value.xmlid,
+        input: asString(value.input),
+        adders,
+        ...(levels === undefined ? {} : {levels}),
+    };
+}
+
+/**
+ * A stored source as a draft, or null when it is not one this build understands.
+ *
+ * **Shape only — this does not check that anything named still exists.** A complication the
+ * edition dropped parses fine here and is caught by `validate`, which is where the player gets
+ * told about it in words. Conflating the two would mean a rules-data change silently locked
+ * people out of their own characters.
+ */
+export function parseSource(source: StoredSource | null | undefined): AuthoredCharacter | null {
+    if (!isObject(source) || !isEdition(source.edition) || !Array.isArray(source.complications)) {
+        return null;
+    }
+
+    const characteristics = parseCharacteristics(source.characteristics);
+
+    if (characteristics === null) {
+        return null;
+    }
+
+    const complications: AuthoredComplication[] = [];
+
+    for (const entry of source.complications) {
+        const complication = parseComplication(entry);
+
+        if (complication === null) {
+            return null;
+        }
+
+        complications.push(complication);
+    }
+
+    return {
+        edition: source.edition,
+        name: asString(source.name),
+        player: asString(source.player),
+        characteristics,
+        complications,
+    };
+}
+
+/** A draft as the JSON the `source` column stores. A plain projection — no engine data rides along. */
+export const toSource = (draft: AuthoredCharacter): StoredSource => ({
+    edition: draft.edition,
+    name: draft.name,
+    player: draft.player,
+    characteristics: {...draft.characteristics},
+    complications: draft.complications.map((entry) => ({
+        xmlid: entry.xmlid,
+        input: entry.input,
+        adders: entry.adders.map((adder) => ({...adder})),
+        ...(entry.levels === undefined ? {} : {levels: entry.levels}),
+    })),
+});

--- a/src/core/authoring/source.ts
+++ b/src/core/authoring/source.ts
@@ -25,7 +25,7 @@
  * edit it does not.
  */
 import type {StoredSource} from 'core/ports';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredComplication, AuthoringEdition} from './types';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredTrait, AuthoringEdition} from './types';
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -74,7 +74,7 @@ function parseAdder(value: unknown): AuthoredAdder | null {
     };
 }
 
-function parseComplication(value: unknown): AuthoredComplication | null {
+function parseTrait(value: unknown): AuthoredTrait | null {
     if (!isObject(value) || typeof value.xmlid !== 'string' || !Array.isArray(value.adders)) {
         return null;
     }
@@ -91,9 +91,21 @@ function parseComplication(value: unknown): AuthoredComplication | null {
         adders.push(adder);
     }
 
-    const {levels} = value;
+    const {levels, option, characteristic, familiarity} = value;
 
     if (levels !== undefined && (typeof levels !== 'number' || !Number.isInteger(levels))) {
+        return null;
+    }
+
+    if (option !== undefined && typeof option !== 'string') {
+        return null;
+    }
+
+    if (characteristic !== undefined && typeof characteristic !== 'string') {
+        return null;
+    }
+
+    if (familiarity !== undefined && typeof familiarity !== 'boolean') {
         return null;
     }
 
@@ -102,7 +114,31 @@ function parseComplication(value: unknown): AuthoredComplication | null {
         input: asString(value.input),
         adders,
         ...(levels === undefined ? {} : {levels}),
+        ...(option === undefined ? {} : {option}),
+        ...(characteristic === undefined ? {} : {characteristic}),
+        ...(familiarity === undefined ? {} : {familiarity}),
     };
+}
+
+/** A whole category, or null if any entry in it is unreadable. */
+function parseTraits(value: unknown): AuthoredTrait[] | null {
+    if (!Array.isArray(value)) {
+        return null;
+    }
+
+    const traits: AuthoredTrait[] = [];
+
+    for (const entry of value) {
+        const parsed = parseTrait(entry);
+
+        if (parsed === null) {
+            return null;
+        }
+
+        traits.push(parsed);
+    }
+
+    return traits;
 }
 
 /**
@@ -114,7 +150,7 @@ function parseComplication(value: unknown): AuthoredComplication | null {
  * people out of their own characters.
  */
 export function parseSource(source: StoredSource | null | undefined): AuthoredCharacter | null {
-    if (!isObject(source) || !isEdition(source.edition) || !Array.isArray(source.complications)) {
+    if (!isObject(source) || !isEdition(source.edition)) {
         return null;
     }
 
@@ -124,16 +160,16 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
         return null;
     }
 
-    const complications: AuthoredComplication[] = [];
+    // Categories added after Phase A: a source written before they existed has no such key, and
+    // reads as empty rather than as unreadable. Refusing it would make a schema addition lock
+    // players out of characters they had already saved.
+    const skills = parseTraits(source.skills ?? []);
+    const perks = parseTraits(source.perks ?? []);
+    const talents = parseTraits(source.talents ?? []);
+    const complications = parseTraits(source.complications ?? []);
 
-    for (const entry of source.complications) {
-        const complication = parseComplication(entry);
-
-        if (complication === null) {
-            return null;
-        }
-
-        complications.push(complication);
+    if (skills === null || perks === null || talents === null || complications === null) {
+        return null;
     }
 
     return {
@@ -141,20 +177,31 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
         name: asString(source.name),
         player: asString(source.player),
         characteristics,
+        skills,
+        perks,
+        talents,
         complications,
     };
 }
 
 /** A draft as the JSON the `source` column stores. A plain projection — no engine data rides along. */
+const traitToSource = (entry: AuthoredTrait): Record<string, unknown> => ({
+    xmlid: entry.xmlid,
+    input: entry.input,
+    adders: entry.adders.map((adder) => ({...adder})),
+    ...(entry.levels === undefined ? {} : {levels: entry.levels}),
+    ...(entry.option === undefined ? {} : {option: entry.option}),
+    ...(entry.characteristic === undefined ? {} : {characteristic: entry.characteristic}),
+    ...(entry.familiarity === undefined ? {} : {familiarity: entry.familiarity}),
+});
+
 export const toSource = (draft: AuthoredCharacter): StoredSource => ({
     edition: draft.edition,
     name: draft.name,
     player: draft.player,
     characteristics: {...draft.characteristics},
-    complications: draft.complications.map((entry) => ({
-        xmlid: entry.xmlid,
-        input: entry.input,
-        adders: entry.adders.map((adder) => ({...adder})),
-        ...(entry.levels === undefined ? {} : {levels: entry.levels}),
-    })),
+    skills: draft.skills.map(traitToSource),
+    perks: draft.perks.map(traitToSource),
+    talents: draft.talents.map(traitToSource),
+    complications: draft.complications.map(traitToSource),
 });

--- a/src/core/authoring/source.ts
+++ b/src/core/authoring/source.ts
@@ -25,7 +25,7 @@
  * edit it does not.
  */
 import type {StoredSource} from 'core/ports';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredFramework, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition, FrameworkKind} from './types';
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -207,6 +207,44 @@ function parsePowers(value: unknown): AuthoredPower[] | null {
     return powers;
 }
 
+const FRAMEWORK_KINDS = new Set<FrameworkKind>(['multipower', 'elementalControl', 'vpp']);
+
+function parseFrameworks(value: unknown): AuthoredFramework[] | null {
+    if (!Array.isArray(value)) {
+        return null;
+    }
+
+    const frameworks: AuthoredFramework[] = [];
+
+    for (const entry of value) {
+        if (!isObject(entry) || !FRAMEWORK_KINDS.has(entry.kind as FrameworkKind) || typeof entry.reserve !== 'number' || !Number.isInteger(entry.reserve)) {
+            return null;
+        }
+
+        const slots = parsePowers(entry.slots ?? []);
+
+        if (slots === null || !Array.isArray(entry.modifiers)) {
+            return null;
+        }
+
+        const modifiers: AuthoredModifier[] = [];
+
+        for (const raw of entry.modifiers) {
+            const parsed = parseModifier(raw);
+
+            if (parsed === null) {
+                return null;
+            }
+
+            modifiers.push(parsed);
+        }
+
+        frameworks.push({kind: entry.kind as FrameworkKind, name: asString(entry.name), reserve: entry.reserve, modifiers, slots});
+    }
+
+    return frameworks;
+}
+
 /**
  * A stored source as a draft, or null when it is not one this build understands.
  *
@@ -234,8 +272,9 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
     const talents = parseTraits(source.talents ?? []);
     const complications = parseTraits(source.complications ?? []);
     const powers = parsePowers(source.powers ?? []);
+    const frameworks = parseFrameworks(source.frameworks ?? []);
 
-    if (skills === null || perks === null || talents === null || complications === null || powers === null) {
+    if (skills === null || perks === null || talents === null || complications === null || powers === null || frameworks === null) {
         return null;
     }
 
@@ -248,11 +287,14 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
         perks,
         talents,
         powers,
+        frameworks,
         complications,
     };
 }
 
 /** A draft as the JSON the `source` column stores. A plain projection — no engine data rides along. */
+const modifierToSource = (mod: AuthoredModifier): Record<string, unknown> => ({...mod, adders: mod.adders.map((adder) => ({...adder}))});
+
 const traitToSource = (entry: AuthoredTrait): Record<string, unknown> => ({
     xmlid: entry.xmlid,
     input: entry.input,
@@ -264,6 +306,12 @@ const traitToSource = (entry: AuthoredTrait): Record<string, unknown> => ({
     ...(entry.familiarity === undefined ? {} : {familiarity: entry.familiarity}),
 });
 
+const powerToSource = (entry: AuthoredPower): Record<string, unknown> => ({
+    ...traitToSource(entry),
+    modifiers: entry.modifiers.map(modifierToSource),
+    ...(entry.defense === undefined ? {} : {defense: {...entry.defense}}),
+});
+
 export const toSource = (draft: AuthoredCharacter): StoredSource => ({
     edition: draft.edition,
     name: draft.name,
@@ -272,10 +320,13 @@ export const toSource = (draft: AuthoredCharacter): StoredSource => ({
     skills: draft.skills.map(traitToSource),
     perks: draft.perks.map(traitToSource),
     talents: draft.talents.map(traitToSource),
-    powers: draft.powers.map((entry) => ({
-        ...traitToSource(entry),
-        modifiers: entry.modifiers.map((mod) => ({...mod, adders: mod.adders.map((adder) => ({...adder}))})),
-        ...(entry.defense === undefined ? {} : {defense: {...entry.defense}}),
+    powers: draft.powers.map(powerToSource),
+    frameworks: draft.frameworks.map((framework) => ({
+        kind: framework.kind,
+        name: framework.name,
+        reserve: framework.reserve,
+        modifiers: framework.modifiers.map(modifierToSource),
+        slots: framework.slots.map(powerToSource),
     })),
     complications: draft.complications.map(traitToSource),
 });

--- a/src/core/authoring/source.ts
+++ b/src/core/authoring/source.ts
@@ -25,7 +25,7 @@
  * edit it does not.
  */
 import type {StoredSource} from 'core/ports';
-import type {AuthoredAdder, AuthoredCharacter, AuthoredTrait, AuthoringEdition} from './types';
+import type {AuthoredAdder, AuthoredCharacter, AuthoredModifier, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
 
 const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -91,7 +91,11 @@ function parseTrait(value: unknown): AuthoredTrait | null {
         adders.push(adder);
     }
 
-    const {levels, option, characteristic, familiarity} = value;
+    const {levels, option, characteristic, familiarity, name} = value;
+
+    if (name !== undefined && typeof name !== 'string') {
+        return null;
+    }
 
     if (levels !== undefined && (typeof levels !== 'number' || !Number.isInteger(levels))) {
         return null;
@@ -113,6 +117,7 @@ function parseTrait(value: unknown): AuthoredTrait | null {
         xmlid: value.xmlid,
         input: asString(value.input),
         adders,
+        ...(name === undefined ? {} : {name}),
         ...(levels === undefined ? {} : {levels}),
         ...(option === undefined ? {} : {option}),
         ...(characteristic === undefined ? {} : {characteristic}),
@@ -141,6 +146,67 @@ function parseTraits(value: unknown): AuthoredTrait[] | null {
     return traits;
 }
 
+function parseModifier(value: unknown): AuthoredModifier | null {
+    const base = parseTrait(value);
+
+    if (base === null || !isObject(value)) {
+        return null;
+    }
+
+    const {text} = value;
+
+    if (text !== undefined && typeof text !== 'string') {
+        return null;
+    }
+
+    return {
+        xmlid: base.xmlid,
+        adders: base.adders,
+        ...(base.levels === undefined ? {} : {levels: base.levels}),
+        ...(base.option === undefined ? {} : {option: base.option}),
+        ...(text === undefined ? {} : {text}),
+    };
+}
+
+const isDefense = (value: unknown): value is {pd: number; ed: number; mental: number; power: number} =>
+    isObject(value) && (['pd', 'ed', 'mental', 'power'] as const).every((key) => typeof value[key] === 'number' && Number.isInteger(value[key]));
+
+function parsePowers(value: unknown): AuthoredPower[] | null {
+    if (!Array.isArray(value)) {
+        return null;
+    }
+
+    const powers: AuthoredPower[] = [];
+
+    for (const entry of value) {
+        const base = parseTrait(entry);
+
+        if (base === null || !isObject(entry) || !Array.isArray(entry.modifiers)) {
+            return null;
+        }
+
+        const modifiers: AuthoredModifier[] = [];
+
+        for (const raw of entry.modifiers) {
+            const parsed = parseModifier(raw);
+
+            if (parsed === null) {
+                return null;
+            }
+
+            modifiers.push(parsed);
+        }
+
+        if (entry.defense !== undefined && !isDefense(entry.defense)) {
+            return null;
+        }
+
+        powers.push({...base, modifiers, ...(entry.defense === undefined ? {} : {defense: entry.defense})});
+    }
+
+    return powers;
+}
+
 /**
  * A stored source as a draft, or null when it is not one this build understands.
  *
@@ -167,8 +233,9 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
     const perks = parseTraits(source.perks ?? []);
     const talents = parseTraits(source.talents ?? []);
     const complications = parseTraits(source.complications ?? []);
+    const powers = parsePowers(source.powers ?? []);
 
-    if (skills === null || perks === null || talents === null || complications === null) {
+    if (skills === null || perks === null || talents === null || complications === null || powers === null) {
         return null;
     }
 
@@ -180,6 +247,7 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
         skills,
         perks,
         talents,
+        powers,
         complications,
     };
 }
@@ -188,6 +256,7 @@ export function parseSource(source: StoredSource | null | undefined): AuthoredCh
 const traitToSource = (entry: AuthoredTrait): Record<string, unknown> => ({
     xmlid: entry.xmlid,
     input: entry.input,
+    ...(entry.name === undefined ? {} : {name: entry.name}),
     adders: entry.adders.map((adder) => ({...adder})),
     ...(entry.levels === undefined ? {} : {levels: entry.levels}),
     ...(entry.option === undefined ? {} : {option: entry.option}),
@@ -203,5 +272,10 @@ export const toSource = (draft: AuthoredCharacter): StoredSource => ({
     skills: draft.skills.map(traitToSource),
     perks: draft.perks.map(traitToSource),
     talents: draft.talents.map(traitToSource),
+    powers: draft.powers.map((entry) => ({
+        ...traitToSource(entry),
+        modifiers: entry.modifiers.map((mod) => ({...mod, adders: mod.adders.map((adder) => ({...adder}))})),
+        ...(entry.defense === undefined ? {} : {defense: {...entry.defense}}),
+    })),
     complications: draft.complications.map(traitToSource),
 });

--- a/src/core/authoring/spend.ts
+++ b/src/core/authoring/spend.ts
@@ -1,0 +1,134 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What a character costs, asked of the engine (docs/CHARACTER_AUTHORING.md).
+ *
+ * Nothing computed this before. `core/hero/characterPoints` reads the **declared**
+ * `<BASIC_CONFIGURATION>` a `.hdc` carries — the points a character was *built on* — and never
+ * sums what it actually spends. That is fine for an imported file, whose author already balanced
+ * it, and useless while authoring, where the running total is the whole point.
+ *
+ * Every number here comes from the trait decorators, never from the catalogue. The templates state
+ * costs and the engine states costs; if this module added them up itself there would be two
+ * answers to every question and no way to tell which was wrong.
+ *
+ * **Complications fund the build, they do not consume it.** In 5E the disadvantage allowance is
+ * added to base points to give the total a character may spend. 6E abolished that: complications
+ * are a required *shape*, worth no points at all. So the two editions read the same numbers to
+ * opposite effect, and `remaining` is the only place that knows it.
+ */
+import {TRAIT_CHILD_KEYS} from 'core/hero';
+import {characterTraitDecorator, type Obj} from 'core/traits';
+import {withDescendants} from 'core/util';
+import type {AuthoringEdition} from './types';
+
+/** The trait buckets a character spends points on, in sheet order. */
+const SPENDING_BUCKETS = ['skills', 'perks', 'talents', 'martialArts', 'powers', 'equipment'] as const;
+
+export interface Spend {
+    /** What the characteristics cost — the engine's own per-characteristic `cost`. */
+    readonly characteristics: number;
+    /** What every trait costs, framework pools and their slots alike. */
+    readonly traits: number;
+    /** Points the complications are worth. Positive; what it *means* is edition-specific. */
+    readonly complications: number;
+    /** characteristics + traits. What the player has actually spent. */
+    readonly spent: number;
+}
+
+const sumBucket = (character: Obj, key: string): number =>
+    withDescendants((character[key] ?? []) as Obj[], TRAIT_CHILD_KEYS[key] ?? ['powers']).reduce((total, trait) => {
+        try {
+            return total + characterTraitDecorator.decorate(trait, key, () => character).realCost();
+        } catch {
+            // A trait the engine cannot price contributes nothing rather than blanking the total.
+            // `validate` is what tells the player about it — see the silent-zero trap in the docs.
+            return total;
+        }
+    }, 0);
+
+/**
+ * What a built character costs, bucket by bucket.
+ *
+ * Takes the **built** character (the engine's output), not a draft, so the sheet and the spend
+ * meter are reading the same object and cannot disagree.
+ */
+export function spendOf(character: Obj): Spend {
+    const characteristics = ((character.characteristics ?? []) as Obj[]).reduce((total, entry) => total + (Number(entry.cost) || 0), 0);
+    const traits = SPENDING_BUCKETS.reduce((total, key) => total + sumBucket(character, key), 0);
+
+    // `cost()`, not `realCost()`: a complication's worth is its base value. The decorator chain's
+    // advantage/limitation multipliers have no meaning on a disadvantage.
+    const complications = withDescendants((character.disadvantages ?? []) as Obj[], TRAIT_CHILD_KEYS.disadvantages).reduce((total, entry) => {
+        try {
+            return total + characterTraitDecorator.decorate(entry, 'disadvantages', () => character).cost();
+        } catch {
+            return total;
+        }
+    }, 0);
+
+    return {characteristics, traits, complications, spent: characteristics + traits};
+}
+
+/**
+ * The budget a character is being built to.
+ *
+ * `base` is what the campaign grants. `complicationLimit` is how much of the build complications
+ * may fund (5E) or how many points' worth are required (6E) — HERO calls both a limit and neither
+ * is a suggestion.
+ */
+export interface Budget {
+    readonly base: number;
+    readonly complicationLimit: number;
+}
+
+/** Standard Superheroic, the level the generator builds to and what a new draft starts at. */
+export const DEFAULT_BUDGET: Readonly<Record<AuthoringEdition, Budget>> = {
+    // 5E: 200 base + up to 150 in disadvantages = the classic 350-point superhero.
+    '5E': {base: 200, complicationLimit: 150},
+    // 6E: 400 is the whole allowance; complications grant nothing and 75 is the required shape.
+    '6E': {base: 400, complicationLimit: 75},
+};
+
+export interface Remaining {
+    /** Everything the player may spend: base, plus the complications that fund it in 5E. */
+    readonly total: number;
+    readonly spent: number;
+    /** `total − spent`. Negative means over budget, which is allowed but shown. */
+    readonly left: number;
+    /** Complications taken, and the most that count. Over the limit, the excess funds nothing. */
+    readonly complications: number;
+    readonly complicationLimit: number;
+}
+
+/**
+ * How much a character has left to spend.
+ *
+ * The edition fork is real and it is here: 5E complications *buy* points, capped at the limit, so
+ * a 5E character's total grows as it takes them. 6E complications buy nothing — the 400 is the
+ * whole allowance and the 75 is a requirement the character must meet, not a source of points.
+ */
+export function remaining(spend: Spend, budget: Budget, edition: AuthoringEdition): Remaining {
+    const counted = Math.min(spend.complications, budget.complicationLimit);
+    const total = edition === '5E' ? budget.base + counted : budget.base;
+
+    return {
+        total,
+        spent: spend.spent,
+        left: total - spend.spent,
+        complications: spend.complications,
+        complicationLimit: budget.complicationLimit,
+    };
+}

--- a/src/core/authoring/spend.ts
+++ b/src/core/authoring/spend.ts
@@ -32,7 +32,7 @@
 import {TRAIT_CHILD_KEYS} from 'core/hero';
 import {characterTraitDecorator, type Obj} from 'core/traits';
 import {withDescendants} from 'core/util';
-import type {AuthoringEdition} from './types';
+import type {AuthoringEdition, Budget} from './types';
 
 /** The trait buckets a character spends points on, in sheet order. */
 const SPENDING_BUCKETS = ['skills', 'perks', 'talents', 'martialArts', 'powers', 'equipment'] as const;
@@ -127,26 +127,6 @@ const describe = (entry: Obj, key: string, character: Obj): TraitSummary => {
         // player has no way to fix or delete it. `validate` is what says why.
         return {label: String(entry.name ?? entry.alias ?? entry.xmlid), cost: 0};
     }
-};
-
-/**
- * The budget a character is being built to.
- *
- * `base` is what the campaign grants. `complicationLimit` is how much of the build complications
- * may fund (5E) or how many points' worth are required (6E) — HERO calls both a limit and neither
- * is a suggestion.
- */
-export interface Budget {
-    readonly base: number;
-    readonly complicationLimit: number;
-}
-
-/** Standard Superheroic, the level the generator builds to and what a new draft starts at. */
-export const DEFAULT_BUDGET: Readonly<Record<AuthoringEdition, Budget>> = {
-    // 5E: 200 base + up to 150 in disadvantages = the classic 350-point superhero.
-    '5E': {base: 200, complicationLimit: 150},
-    // 6E: 400 is the whole allowance; complications grant nothing and 75 is the required shape.
-    '6E': {base: 400, complicationLimit: 75},
 };
 
 export interface Remaining {

--- a/src/core/authoring/spend.ts
+++ b/src/core/authoring/spend.ts
@@ -82,6 +82,53 @@ export function spendOf(character: Obj): Spend {
     return {characteristics, traits, complications, spent: characteristics + traits};
 }
 
+/** What one row of an authoring list should say: what it is, and what it costs. */
+export interface TraitSummary {
+    readonly label: string;
+    readonly cost: number;
+}
+
+/**
+ * A label and a cost for every trait in a category, in draft order.
+ *
+ * So a list can show what each entry costs without every entry's form being on screen. Priced by
+ * decorating the *built* character, so a row and the meter above it are reading the same numbers —
+ * the alternative is a second cost model that agrees until it doesn't.
+ *
+ * Order is draft order because `emit` assigns `position` from the array index and the engine sorts
+ * on it. Frameworks are excluded here: they nest, so a flat list of them is the wrong shape —
+ * {@link frameworkSummaries} handles those.
+ */
+export function summaries(character: Obj, key: string): TraitSummary[] {
+    // Framework containers are not entries in any draft list, so they are skipped: `draft.powers`
+    // holds only the standalone ones, and a container would shift every index after it.
+    const entries = ((character[key] ?? []) as Obj[]).filter((entry) => entry.type !== 'list');
+
+    return entries.map((entry) => describe(entry, key, character));
+}
+
+/** A container's own label and cost, plus one per slot — the shape a framework card wants. */
+export function frameworkSummaries(character: Obj): Array<{container: TraitSummary; slots: TraitSummary[]}> {
+    return ((character.powers ?? []) as Obj[])
+        .filter((entry) => entry.type === 'list')
+        .map((container) => ({
+            container: describe(container, 'powers', character),
+            slots: ((container.powers ?? []) as Obj[]).map((slot) => describe(slot, 'powers', character)),
+        }));
+}
+
+const describe = (entry: Obj, key: string, character: Obj): TraitSummary => {
+    try {
+        const decorated = characterTraitDecorator.decorate(entry, key, () => character);
+
+        return {label: decorated.label(), cost: decorated.realCost()};
+    } catch {
+        // A trait the engine cannot render still needs a row, or it vanishes from the list and the
+        // player has no way to fix or delete it. `validate` is what says why.
+        return {label: String(entry.name ?? entry.alias ?? entry.xmlid), cost: 0};
+    }
+};
+
 /**
  * The budget a character is being built to.
  *

--- a/src/core/authoring/spend.ts
+++ b/src/core/authoring/spend.ts
@@ -130,11 +130,19 @@ const describe = (entry: Obj, key: string, character: Obj): TraitSummary => {
 };
 
 export interface Remaining {
-    /** Everything the player may spend: base, plus the complications that fund it in 5E. */
+    /** Everything the campaign grants: base, plus the complications that fund it in 5E. */
     readonly total: number;
     readonly spent: number;
-    /** `total − spent`. Negative means over budget, which is allowed but shown. */
+    /** What is left of the allowance. Never negative — past it, the excess is experience. */
     readonly left: number;
+    /**
+     * Points spent beyond the campaign's allowance.
+     *
+     * Not an error, and not an overspend: in HERO a character who costs more than their starting
+     * allowance has **earned** the difference, and that is what experience is. The sheet's
+     * nameplate already prints it — `"400 + 25 pts"` — so all this has to do is say how much.
+     */
+    readonly experience: number;
     /** Complications taken, and the most that count. Over the limit, the excess funds nothing. */
     readonly complications: number;
     readonly complicationLimit: number;
@@ -154,7 +162,8 @@ export function remaining(spend: Spend, budget: Budget, edition: AuthoringEditio
     return {
         total,
         spent: spend.spent,
-        left: total - spend.spent,
+        left: Math.max(0, total - spend.spent),
+        experience: Math.max(0, spend.spent - total),
         complications: spend.complications,
         complicationLimit: budget.complicationLimit,
     };

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -190,6 +190,16 @@ export interface AuthoredCharacter {
     readonly perks: readonly AuthoredTrait[];
     readonly talents: readonly AuthoredTrait[];
     readonly powers: readonly AuthoredPower[];
+    /**
+     * Martial maneuvers. Not powers, and kept in their own `.hdc` bucket — but their cost comes
+     * out of the same pot, which is why `core/random`'s allocator counts them with the powers.
+     */
+    readonly martialArts: readonly AuthoredTrait[];
+    /**
+     * Carried gear. Powers in every respect the engine cares about — same catalogue, same
+     * modifiers — but its own category, so a sword and an innate power stay told apart on the sheet.
+     */
+    readonly equipment: readonly AuthoredPower[];
     readonly frameworks: readonly AuthoredFramework[];
     readonly complications: readonly AuthoredTrait[];
 }
@@ -204,6 +214,8 @@ export const emptyDraft = (edition: AuthoringEdition): AuthoredCharacter => ({
     perks: [],
     talents: [],
     powers: [],
+    martialArts: [],
+    equipment: [],
     frameworks: [],
     complications: [],
 });

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -25,8 +25,86 @@
  * so it names things and lets the current template data answer.
  */
 
+import type {BasicConfiguration} from 'core/hero';
+import {POWER_LEVELS} from 'core/random';
+
 /** Which rulebook a draft is built against. The single fork the whole engine follows. */
 export type AuthoringEdition = '5E' | '6E';
+
+/**
+ * The budget a character is being built to.
+ *
+ * `base` is what the campaign grants, **quoted the way that edition quotes it** — a 5E character's
+ * pre-disadvantage base, a 6E character's whole allowance. `complicationLimit` is how much of the
+ * build complications may fund (5E) or how many points' worth are required (6E); HERO calls both a
+ * limit and neither is a suggestion.
+ *
+ * Plain numbers rather than the id of a preset, so a GM running a campaign the rulebook has no
+ * name for can still say what it allows. The presets are a convenience over these, not a
+ * replacement for them.
+ */
+export interface Budget {
+    readonly base: number;
+    readonly complicationLimit: number;
+}
+
+/** A named campaign level, as something to pick. */
+export interface PointAllowance extends Budget {
+    readonly id: string;
+    readonly name: string;
+    readonly edition: AuthoringEdition;
+}
+
+/**
+ * The campaign levels a character can be authored at.
+ *
+ * Derived from `core/random`'s `POWER_LEVELS` rather than restated, because those numbers are
+ * already checked against both rulebooks and a second copy is exactly how the legacy
+ * `skillsets.json` came to disagree with itself about what a profession cost.
+ *
+ * **The two editions are quoted in different units**, which is the easiest thing here to get
+ * wrong — `powerLevel.ts` spells it out: 5E quotes base and adds disadvantages, 6E quotes the
+ * total and subtracts complications. So a 6E allowance's `base` is the level's *total*, and a 5E
+ * one's is its *base*. That is the same conversion `declaredConfiguration` makes when it writes a
+ * character's `<BASIC_CONFIGURATION>`, which is why an authored character's declared points come
+ * out agreeing with a generated one's.
+ */
+export const POINT_ALLOWANCES: readonly PointAllowance[] = POWER_LEVELS.map((level) => ({
+    id: level.id,
+    name: level.name,
+    edition: level.edition === '6e' ? '6E' : '5E',
+    base: level.edition === '6e' ? level.total : level.base,
+    complicationLimit: level.limit,
+}));
+
+/** The allowances offered for an edition. */
+export const allowancesFor = (edition: AuthoringEdition): PointAllowance[] => POINT_ALLOWANCES.filter((allowance) => allowance.edition === edition);
+
+/** The named allowance matching a budget exactly, or null when it has been hand-set. */
+export const allowanceFor = (budget: Budget, edition: AuthoringEdition): PointAllowance | null =>
+    allowancesFor(edition).find((allowance) => allowance.base === budget.base && allowance.complicationLimit === budget.complicationLimit) ?? null;
+
+/** Just the two numbers — an allowance carries a name and an id that a draft has no use for. */
+const budgetOf = (id: string): Budget => {
+    const allowance = POINT_ALLOWANCES.find((candidate) => candidate.id === id)!;
+
+    return {base: allowance.base, complicationLimit: allowance.complicationLimit};
+};
+
+/** Where a new draft starts: Standard Superheroic, the level the generator builds to. */
+export const DEFAULT_BUDGET: Readonly<Record<AuthoringEdition, Budget>> = {
+    '5E': budgetOf('5e-standard'),
+    '6E': budgetOf('6e-standard'),
+};
+
+/**
+ * The `<BASIC_CONFIGURATION>` a character built to this budget declares.
+ *
+ * Without it the sheet's nameplate shows no points and no campaign tier — `pointSummary` reads the
+ * declared block and returns null when it is absent, which is what an authored character did
+ * before this. Both numbers are already in the edition's own units, so no conversion happens here.
+ */
+export const declaredFor = (budget: Budget): BasicConfiguration => ({basePoints: budget.base, disadPoints: budget.complicationLimit, experience: 0});
 
 /**
  * A chosen adder on a trait: the adder's xmlid, plus the option xmlid when it offers a list.
@@ -184,6 +262,15 @@ export interface AuthoredCharacter {
     readonly edition: AuthoringEdition;
     readonly name: string;
     readonly player: string;
+    /**
+     * What the campaign allows — see `Budget`.
+     *
+     * Part of the draft rather than a screen setting, because it is part of the character: it is
+     * what the sheet's nameplate declares and what the campaign tier is read from. A character
+     * re-opened at a different allowance than it was built to would silently be over or under
+     * budget for reasons nobody could see.
+     */
+    readonly budget: Budget;
     /** Characteristic totals by lower-case key: `{str: 20, dex: 15}`. Absent = leave at base. */
     readonly characteristics: Readonly<Record<string, number>>;
     readonly skills: readonly AuthoredTrait[];
@@ -209,6 +296,7 @@ export const emptyDraft = (edition: AuthoringEdition): AuthoredCharacter => ({
     edition,
     name: '',
     player: '',
+    budget: DEFAULT_BUDGET[edition],
     characteristics: {},
     skills: [],
     perks: [],

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -102,9 +102,19 @@ export const DEFAULT_BUDGET: Readonly<Record<AuthoringEdition, Budget>> = {
  *
  * Without it the sheet's nameplate shows no points and no campaign tier — `pointSummary` reads the
  * declared block and returns null when it is absent, which is what an authored character did
- * before this. Both numbers are already in the edition's own units, so no conversion happens here.
+ * before this. The base and the limit are already in the edition's own units, so no conversion
+ * happens here.
+ *
+ * `experience` is whatever the character costs past its allowance. That is what experience *is* in
+ * HERO — a character who costs more than their starting points has earned the difference — and it
+ * is why going over is not an error. The tier stays keyed on base alone, deliberately:
+ * `powerTier` does not let a character climb the campaign ladder by earning points.
  */
-export const declaredFor = (budget: Budget): BasicConfiguration => ({basePoints: budget.base, disadPoints: budget.complicationLimit, experience: 0});
+export const declaredFor = (budget: Budget, experience = 0): BasicConfiguration => ({
+    basePoints: budget.base,
+    disadPoints: budget.complicationLimit,
+    experience: Math.max(0, Math.round(experience)),
+});
 
 /**
  * A chosen adder on a trait: the adder's xmlid, plus the option xmlid when it offers a list.

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -48,19 +48,43 @@ export interface AuthoredAdder {
 }
 
 /**
- * One complication the player has taken.
+ * One trait the player has taken — a skill, perk, talent or complication.
+ *
+ * The same shape for all four because the `.hdc` format treats them the same way: an xmlid, some
+ * free text, a pick-one, a number of levels, and a list of adders. What differs is which of those
+ * a given entry declares, and the template says that — see `CatalogueTrait`.
  *
  * `input` is the free text the template asks for under its own `inputlabel` — "Code Of The Hero"
- * for a Psychological Complication. Its presence is what makes the sheet label read
- * "Psychological: Code Of The Hero" rather than the bare template name, so it is not decoration.
+ * for a Psychological Complication, "French" for a Language. Its presence is what makes a sheet
+ * label read "Psychological: Code Of The Hero" rather than the bare template name, so it is not
+ * decoration.
  */
-export interface AuthoredComplication {
+export interface AuthoredTrait {
     readonly xmlid: string;
     readonly input: string;
     readonly adders: readonly AuthoredAdder[];
-    /** Levels, for the handful priced by them (UNLUCK). */
+    /** Levels bought, for anything priced by them — Skill Levels, Contacts, Unluck. */
     readonly levels?: number;
+    /** The chosen entry-level option: a Language's fluency, a Skill Level's breadth. */
+    readonly option?: string;
+    /**
+     * Which characteristic a skill rolls against — `DEX` for Acrobatics, `INT` or `GENERAL` for a
+     * Knowledge Skill. Required for any skill the template gives a `characteristicChoice`: without
+     * it `Skill.cost()` falls through to the trait's own basecost, which for most skills is absent.
+     */
+    readonly characteristic?: string;
+    /**
+     * Taken at familiarity — an 8- roll for a point, instead of the full skill.
+     *
+     * A separate flag rather than "0 levels", because they are different purchases: a familiarity
+     * costs 1 and rolls 8-, where the same skill bought normally costs 3 and rolls off a
+     * characteristic.
+     */
+    readonly familiarity?: boolean;
 }
+
+/** Kept as its own name because the rules, the UI and the sheet all call them complications. */
+export type AuthoredComplication = AuthoredTrait;
 
 /**
  * A character being authored.
@@ -75,7 +99,10 @@ export interface AuthoredCharacter {
     readonly player: string;
     /** Characteristic totals by lower-case key: `{str: 20, dex: 15}`. Absent = leave at base. */
     readonly characteristics: Readonly<Record<string, number>>;
-    readonly complications: readonly AuthoredComplication[];
+    readonly skills: readonly AuthoredTrait[];
+    readonly perks: readonly AuthoredTrait[];
+    readonly talents: readonly AuthoredTrait[];
+    readonly complications: readonly AuthoredTrait[];
 }
 
 /** An empty draft at an edition — what "new character" starts from. */
@@ -84,5 +111,8 @@ export const emptyDraft = (edition: AuthoringEdition): AuthoredCharacter => ({
     name: '',
     player: '',
     characteristics: {},
+    skills: [],
+    perks: [],
+    talents: [],
     complications: [],
 });

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -61,6 +61,13 @@ export interface AuthoredAdder {
  */
 export interface AuthoredTrait {
     readonly xmlid: string;
+    /**
+     * The player's own name for it — "Fire Bolt" for a Blast.
+     *
+     * Distinct from `input`, which answers a question the template asked. A name is what the sheet
+     * leads with, printing "Fire Bolt (Blast)" where an unnamed one is just "Blast".
+     */
+    readonly name?: string;
     readonly input: string;
     readonly adders: readonly AuthoredAdder[];
     /** Levels bought, for anything priced by them — Skill Levels, Contacts, Unluck. */
@@ -87,6 +94,50 @@ export interface AuthoredTrait {
 export type AuthoredComplication = AuthoredTrait;
 
 /**
+ * An advantage or limitation on a power.
+ *
+ * The same shape as an adder, plus its own adders — HERO lets a modifier be modified, and Area Of
+ * Effect is the everyday case: a Radius has an "Accurate" adder of its own.
+ *
+ * Whether it is an advantage or a limitation is not recorded here, because it is not a choice: the
+ * sign of its cost decides, and `ModifierCalculator` splits them on exactly that. Storing a flag
+ * would let a draft disagree with the rules about which is which.
+ */
+export interface AuthoredModifier {
+    readonly xmlid: string;
+    readonly option?: string;
+    readonly levels?: number;
+    readonly text?: string;
+    readonly adders: readonly AuthoredAdder[];
+}
+
+/**
+ * The four defences a Resistant Protection is split across.
+ *
+ * A `.hdc` records the split *and* a `levels` total, and across all 37 corpus characters the total
+ * is always the sum of the four. So the emitter derives it rather than asking twice — the power
+ * costs by `levels` and grants defence by the split, and the two disagreeing is not a state worth
+ * being able to represent.
+ *
+ * Its own field rather than four more adders because it is a genuine gap: nothing in the template
+ * declares these, and `getResistantDefense` reads them straight off the trait. Without them a
+ * Resistant Protection costs full price and grants nothing at all, quietly.
+ */
+export interface AuthoredDefense {
+    readonly pd: number;
+    readonly ed: number;
+    readonly mental: number;
+    readonly power: number;
+}
+
+/** A power: a trait, plus the advantages and limitations that make it cost what it costs. */
+export interface AuthoredPower extends AuthoredTrait {
+    readonly modifiers: readonly AuthoredModifier[];
+    /** Only for the powers whose catalogue entry declares a `defense` field group. */
+    readonly defense?: AuthoredDefense;
+}
+
+/**
  * A character being authored.
  *
  * Characteristics are **totals**, the number a player actually thinks in ("STR 20"), not the
@@ -102,6 +153,7 @@ export interface AuthoredCharacter {
     readonly skills: readonly AuthoredTrait[];
     readonly perks: readonly AuthoredTrait[];
     readonly talents: readonly AuthoredTrait[];
+    readonly powers: readonly AuthoredPower[];
     readonly complications: readonly AuthoredTrait[];
 }
 
@@ -114,5 +166,6 @@ export const emptyDraft = (edition: AuthoringEdition): AuthoredCharacter => ({
     skills: [],
     perks: [],
     talents: [],
+    powers: [],
     complications: [],
 });

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -130,6 +130,42 @@ export interface AuthoredDefense {
     readonly power: number;
 }
 
+/**
+ * The three power frameworks, named as the `.hdc` names them.
+ *
+ * These strings are load-bearing twice over: they are the sub-key a container is emitted under,
+ * which is what `normalizeCharacterItems` turns into `originalType`, and `originalType` is what
+ * `isPowerFrameworkItem` matches to decide how a slot is priced. Spelling one differently means
+ * the container still parses and the slots still cost full price.
+ */
+export type FrameworkKind = 'multipower' | 'elementalControl' | 'vpp';
+
+/**
+ * A power framework: a pool of points, and the powers that draw on it.
+ *
+ * Its own list rather than a kind of power, because a framework is not priced like one — the
+ * container costs its reserve, and each slot costs a fraction of what it would cost alone. The
+ * three kinds do that arithmetic differently, which is the whole reason to have them.
+ *
+ * A framework carries modifiers like any power: a Unified Power on the pool applies to every slot
+ * in it, which `ModifierCalculator` handles by reading the parent's modifiers as well as the
+ * slot's own.
+ */
+export interface AuthoredFramework {
+    readonly kind: FrameworkKind;
+    readonly name: string;
+    /**
+     * Points in the pool.
+     *
+     * Emitted as the container's `basecost` for a Multipower or Elemental Control, and as its
+     * `levels` for a Variable Power Pool — the format uses different fields, and
+     * `VariablePowerPool.cost()` reads `levels` where the other two read `basecost`.
+     */
+    readonly reserve: number;
+    readonly modifiers: readonly AuthoredModifier[];
+    readonly slots: readonly AuthoredPower[];
+}
+
 /** A power: a trait, plus the advantages and limitations that make it cost what it costs. */
 export interface AuthoredPower extends AuthoredTrait {
     readonly modifiers: readonly AuthoredModifier[];
@@ -154,6 +190,7 @@ export interface AuthoredCharacter {
     readonly perks: readonly AuthoredTrait[];
     readonly talents: readonly AuthoredTrait[];
     readonly powers: readonly AuthoredPower[];
+    readonly frameworks: readonly AuthoredFramework[];
     readonly complications: readonly AuthoredTrait[];
 }
 
@@ -167,5 +204,6 @@ export const emptyDraft = (edition: AuthoringEdition): AuthoredCharacter => ({
     perks: [],
     talents: [],
     powers: [],
+    frameworks: [],
     complications: [],
 });

--- a/src/core/authoring/types.ts
+++ b/src/core/authoring/types.ts
@@ -1,0 +1,88 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * What a player has built, as data — the authoring **draft** (docs/CHARACTER_AUTHORING.md).
+ *
+ * This is deliberately *not* a `ParsedCharacter`. A draft says what the player chose; `emit` turns
+ * it into the `.hdc`-shaped input the engine reads. Keeping them apart is what makes the draft
+ * safe to store and safe to re-open: it carries no engine boilerplate to drift, no ids to collide,
+ * and no display strings to fall out of step with the templates that produce them.
+ *
+ * Every reference is **by xmlid**, never by resolved object — the same discipline
+ * `core/random`'s recipe uses, and for the same reason. A draft outlives the build that wrote it,
+ * so it names things and lets the current template data answer.
+ */
+
+/** Which rulebook a draft is built against. The single fork the whole engine follows. */
+export type AuthoringEdition = '5E' | '6E';
+
+/**
+ * A chosen adder on a trait: the adder's xmlid, plus the option xmlid when it offers a list.
+ *
+ * The cost is *not* here. It lives in the template and is copied in at emit time, so a draft
+ * saved before a template correction re-prices itself rather than preserving the old number.
+ */
+export interface AuthoredAdder {
+    readonly xmlid: string;
+    /** The chosen `option` xmlid, when the adder declares an `option` list. */
+    readonly option?: string;
+    /** Levels, when the adder is bought in levels (`lvlval`/`lvlcost`). */
+    readonly levels?: number;
+    /**
+     * The player's words, for an adder whose "option" is really a free-text field
+     * (see {@link CatalogueAdder.freeText}). Rivalry's description is the only one.
+     */
+    readonly text?: string;
+}
+
+/**
+ * One complication the player has taken.
+ *
+ * `input` is the free text the template asks for under its own `inputlabel` — "Code Of The Hero"
+ * for a Psychological Complication. Its presence is what makes the sheet label read
+ * "Psychological: Code Of The Hero" rather than the bare template name, so it is not decoration.
+ */
+export interface AuthoredComplication {
+    readonly xmlid: string;
+    readonly input: string;
+    readonly adders: readonly AuthoredAdder[];
+    /** Levels, for the handful priced by them (UNLUCK). */
+    readonly levels?: number;
+}
+
+/**
+ * A character being authored.
+ *
+ * Characteristics are **totals**, the number a player actually thinks in ("STR 20"), not the
+ * levels-above-base the `.hdc` stores. `emit` converts, reusing the engine to do it so 5E's
+ * figured characteristics stay the engine's problem — see `core/random/characteristics`.
+ */
+export interface AuthoredCharacter {
+    readonly edition: AuthoringEdition;
+    readonly name: string;
+    readonly player: string;
+    /** Characteristic totals by lower-case key: `{str: 20, dex: 15}`. Absent = leave at base. */
+    readonly characteristics: Readonly<Record<string, number>>;
+    readonly complications: readonly AuthoredComplication[];
+}
+
+/** An empty draft at an edition — what "new character" starts from. */
+export const emptyDraft = (edition: AuthoringEdition): AuthoredCharacter => ({
+    edition,
+    name: '',
+    player: '',
+    characteristics: {},
+    complications: [],
+});

--- a/src/core/authoring/validate.ts
+++ b/src/core/authoring/validate.ts
@@ -32,7 +32,7 @@
  *   - `warning` — legal, priced correctly, but probably not what was meant (over budget, blank).
  */
 import {AUTHORABLE_CATEGORIES, characteristics, complications, modifier, trait, type AuthorableCategory, type CatalogueTrait} from './catalogue';
-import type {AuthoredCharacter, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
+import type {AuthoredCharacter, AuthoredFramework, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
 
 export type Severity = 'error' | 'warning';
 
@@ -246,6 +246,42 @@ function validatePower(power: AuthoredPower, index: number, edition: AuthoringEd
     return problems;
 }
 
+/** What each kind of pool is called where a player will read it. */
+const FRAMEWORK_NOUN: Readonly<Record<AuthoredFramework['kind'], string>> = {
+    multipower: 'Multipower',
+    elementalControl: 'Elemental Control',
+    vpp: 'Variable Power Pool',
+};
+
+/**
+ * A framework, its reserve, and the slots that draw on it.
+ *
+ * The two rules worth enforcing are the ones that produce a *plausible* character rather than a
+ * broken one, which is why they are errors: a framework with no reserve prices its slots at
+ * nothing, and an Elemental Control slot cheaper than the pool comes out negative and quietly
+ * refunds points.
+ */
+function validateFramework(framework: AuthoredFramework, index: number, edition: AuthoringEdition): Problem[] {
+    const path = `frameworks[${index}]`;
+    const problems: Problem[] = [];
+    const noun = FRAMEWORK_NOUN[framework.kind];
+
+    if (!Number.isInteger(framework.reserve) || framework.reserve <= 0) {
+        problems.push({severity: 'error', path, message: `${noun} needs a reserve of at least 1 point.`});
+    }
+
+    if (framework.slots.length === 0) {
+        problems.push({severity: 'warning', path, message: `${noun} has no powers in it.`});
+    }
+
+    framework.slots.forEach((slot, order) => {
+        problems.push(...validateTrait(slot, 'powers', order, edition).map((problem) => ({...problem, path})));
+        problems.push(...validatePower(slot, order, edition).map((problem) => ({...problem, path})));
+    });
+
+    return problems;
+}
+
 /**
  * Everything wrong with a draft, most severe first.
  *
@@ -288,6 +324,7 @@ export function validate(draft: AuthoredCharacter): Problem[] {
     }
 
     draft.powers.forEach((power, index) => problems.push(...validatePower(power, index, draft.edition)));
+    draft.frameworks.forEach((framework, index) => problems.push(...validateFramework(framework, index, draft.edition)));
 
     return [...problems].sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'error' ? -1 : 1));
 }

--- a/src/core/authoring/validate.ts
+++ b/src/core/authoring/validate.ts
@@ -52,6 +52,7 @@ const CATEGORY_NOUN: Readonly<Record<AuthorableCategory, string>> = {
     perks: 'perk',
     talents: 'talent',
     powers: 'power',
+    martialArts: 'maneuver',
     disadvantages: 'complication',
 };
 
@@ -181,11 +182,12 @@ function validateTraitFields(authored: AuthoredTrait, catalogue: CatalogueTrait,
 const authorableCharacteristics = (edition: AuthoringEdition): ReadonlySet<string> => new Set(characteristics(edition).map((entry) => entry.key));
 
 /** Where each catalogue category lives on a draft — `disadvantages` is called `complications` there. */
-const DRAFT_KEY: Readonly<Record<AuthorableCategory, 'skills' | 'perks' | 'talents' | 'powers' | 'complications'>> = {
+const DRAFT_KEY: Readonly<Record<AuthorableCategory, 'skills' | 'perks' | 'talents' | 'powers' | 'martialArts' | 'complications'>> = {
     skills: 'skills',
     perks: 'perks',
     talents: 'talents',
     powers: 'powers',
+    martialArts: 'martialArts',
     disadvantages: 'complications',
 };
 
@@ -324,6 +326,29 @@ export function validate(draft: AuthoredCharacter): Problem[] {
     }
 
     draft.powers.forEach((power, index) => problems.push(...validatePower(power, index, draft.edition)));
+
+    // Equipment is powers in a different bucket, so it gets the powers rules — including the
+    // field groups, so a Resistant Protection vest defends like a Resistant Protection.
+    draft.equipment.forEach((item, index) => {
+        const path = `equipment[${index}]`;
+
+        problems.push(...validateTrait(item, 'powers', index, draft.edition).map((problem) => ({...problem, path})));
+        problems.push(...validatePower(item, index, draft.edition).map((problem) => ({...problem, path})));
+
+        // The engine's totals read `character.powers` and never `character.equipment`, so a
+        // defensive item costs its points and adds nothing to PD/ED. Worth saying out loud: the
+        // player would otherwise see the cost, see the defences on the row, and reasonably assume
+        // they applied.
+        if (item.defense !== undefined) {
+            const entry = trait(item.xmlid, 'powers', draft.edition);
+
+            problems.push({
+                severity: 'warning',
+                path,
+                message: `${entry?.display ?? item.xmlid} is equipment, so its defences will not add to the character's totals.`,
+            });
+        }
+    });
     draft.frameworks.forEach((framework, index) => problems.push(...validateFramework(framework, index, draft.edition)));
 
     return [...problems].sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'error' ? -1 : 1));

--- a/src/core/authoring/validate.ts
+++ b/src/core/authoring/validate.ts
@@ -1,0 +1,157 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Whether a draft is something the engine can actually price
+ * (docs/CHARACTER_AUTHORING.md).
+ *
+ * **This has no counterpart anywhere else in the codebase, and that is the point.** `getCharacter`
+ * prices; it does not judge. Nothing needed to judge before, because a `.hdc` from HERO Designer
+ * was legal by construction. An authoring UI is a machine for producing inputs that might not be.
+ *
+ * The failure mode it exists to stop is silent, not loud. A trait whose xmlid the edition does not
+ * define resolves to no template and prices at **0**, reading on the sheet as though somebody
+ * authored a free power — `LACKOFWEAKNESS`, `SEDUCTION`, `AREA_KNOWLEDGE` and
+ * `LIGHTNING_REFLEXES_SINGLE` have all done exactly this in shipped builds. Worse, in the app the
+ * decorator *throws* on such a trait and `characterSheet` catches it, degrading the row to a
+ * cost-0 stub. So a typo does not crash: it quietly makes the character cheaper.
+ *
+ * Severity is the useful distinction, not legality:
+ *   - `error`   — the engine will mis-price or refuse this. Saving it produces a wrong character.
+ *   - `warning` — legal, priced correctly, but probably not what was meant (over budget, blank).
+ */
+import {characteristics, complication, complications} from './catalogue';
+import type {AuthoredCharacter, AuthoredComplication, AuthoringEdition} from './types';
+
+export type Severity = 'error' | 'warning';
+
+export interface Problem {
+    readonly severity: Severity;
+    /** Where it is, so the UI can point at the offending row: `complications[2]`, `name`. */
+    readonly path: string;
+    readonly message: string;
+}
+
+/** True when nothing is an `error`. Warnings never block a save — they are advice. */
+export const isSaveable = (problems: readonly Problem[]): boolean => !problems.some((problem) => problem.severity === 'error');
+
+function validateComplication(authored: AuthoredComplication, index: number, edition: AuthoringEdition): Problem[] {
+    const path = `complications[${index}]`;
+    const catalogue = complication(authored.xmlid, edition);
+
+    if (catalogue === null) {
+        return [
+            {
+                severity: 'error',
+                path,
+                // The specific trap: not "unknown", but "this edition doesn't have it". 6E deleted
+                // entries 5E had, and the engine's answer to a missing template is 0, not an error.
+                message: `${edition} has no complication "${authored.xmlid}". It would price at 0 rather than fail.`,
+            },
+        ];
+    }
+
+    const problems: Problem[] = [];
+    const chosen = new Map(authored.adders.map((adder) => [adder.xmlid, adder]));
+
+    for (const adder of catalogue.adders) {
+        const answer = chosen.get(adder.xmlid);
+
+        if (adder.required && answer === undefined) {
+            problems.push({severity: 'error', path, message: `${catalogue.display} needs its "${adder.display}".`});
+            continue;
+        }
+
+        if (answer === undefined) {
+            continue;
+        }
+
+        if (adder.freeText && (answer.text ?? '').trim() === '') {
+            // Its optionAlias becomes a bare "(", and `Complication.label()` slices that to "".
+            problems.push({severity: 'error', path, message: `"${adder.display}" needs some text — it is what the sheet prints.`});
+        }
+
+        if (!adder.freeText && adder.options.length > 0 && !adder.options.some((option) => option.xmlid === answer.option)) {
+            problems.push({
+                severity: 'error',
+                path,
+                message: `"${adder.display}" needs one of: ${adder.options.map((option) => option.display).join(', ')}.`,
+            });
+        }
+
+        if (adder.levels !== null && answer.levels !== undefined && (answer.levels < adder.levels.min || answer.levels > adder.levels.max)) {
+            problems.push({
+                severity: 'error',
+                path,
+                message: `"${adder.display}" must be between ${adder.levels.min} and ${adder.levels.max}.`,
+            });
+        }
+    }
+
+    // `input` is what makes the label read "Psychological: Code Of The Hero". Without it the row
+    // is still priced correctly, so this is advice rather than an error.
+    if (catalogue.inputLabel !== null && authored.input.trim() === '') {
+        problems.push({severity: 'warning', path, message: `${catalogue.display} has no "${catalogue.inputLabel}" — the sheet will show only its type.`});
+    }
+
+    return problems;
+}
+
+/**
+ * Every characteristic key this edition defines, as a set — anything else is not authorable.
+ * Derived from the same catalogue the UI renders, so the two cannot disagree about what exists.
+ */
+const authorableCharacteristics = (edition: AuthoringEdition): ReadonlySet<string> => new Set(characteristics(edition).map((entry) => entry.key));
+
+/**
+ * Everything wrong with a draft, most severe first.
+ *
+ * Deliberately exhaustive rather than fail-fast: a player fixing one field wants to see the other
+ * three, not discover them one save at a time.
+ */
+export function validate(draft: AuthoredCharacter): Problem[] {
+    const problems: Problem[] = [];
+
+    if (draft.name.trim() === '') {
+        problems.push({severity: 'warning', path: 'name', message: 'The character has no name.'});
+    }
+
+    const defined = authorableCharacteristics(draft.edition);
+
+    for (const [key, total] of Object.entries(draft.characteristics)) {
+        if (!defined.has(key)) {
+            problems.push({
+                severity: 'error',
+                path: `characteristics.${key}`,
+                // COM is 5E-only, OCV/DCV/OMCV/DMCV are 6E-only. Emitting one the template lacks
+                // is not survivable: `getCharacteristicFields` reads its definition with no guard.
+                message: `${draft.edition} has no "${key.toUpperCase()}".`,
+            });
+            continue;
+        }
+
+        if (!Number.isFinite(total) || !Number.isInteger(total)) {
+            problems.push({severity: 'error', path: `characteristics.${key}`, message: `${key.toUpperCase()} must be a whole number.`});
+        }
+    }
+
+    const known = new Set(complications(draft.edition).map((entry) => entry.xmlid));
+    if (draft.complications.length === 0 && known.size > 0) {
+        problems.push({severity: 'warning', path: 'complications', message: 'No complications taken.'});
+    }
+
+    draft.complications.forEach((entry, index) => problems.push(...validateComplication(entry, index, draft.edition)));
+
+    return [...problems].sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'error' ? -1 : 1));
+}

--- a/src/core/authoring/validate.ts
+++ b/src/core/authoring/validate.ts
@@ -31,8 +31,8 @@
  *   - `error`   — the engine will mis-price or refuse this. Saving it produces a wrong character.
  *   - `warning` — legal, priced correctly, but probably not what was meant (over budget, blank).
  */
-import {characteristics, complication, complications} from './catalogue';
-import type {AuthoredCharacter, AuthoredComplication, AuthoringEdition} from './types';
+import {AUTHORABLE_CATEGORIES, characteristics, complications, trait, type AuthorableCategory, type CatalogueTrait} from './catalogue';
+import type {AuthoredCharacter, AuthoredTrait, AuthoringEdition} from './types';
 
 export type Severity = 'error' | 'warning';
 
@@ -46,9 +46,17 @@ export interface Problem {
 /** True when nothing is an `error`. Warnings never block a save — they are advice. */
 export const isSaveable = (problems: readonly Problem[]): boolean => !problems.some((problem) => problem.severity === 'error');
 
-function validateComplication(authored: AuthoredComplication, index: number, edition: AuthoringEdition): Problem[] {
-    const path = `complications[${index}]`;
-    const catalogue = complication(authored.xmlid, edition);
+/** What the player calls each category, for a message they can act on. */
+const CATEGORY_NOUN: Readonly<Record<AuthorableCategory, string>> = {
+    skills: 'skill',
+    perks: 'perk',
+    talents: 'talent',
+    disadvantages: 'complication',
+};
+
+function validateTrait(authored: AuthoredTrait, category: AuthorableCategory, index: number, edition: AuthoringEdition): Problem[] {
+    const path = `${category}[${index}]`;
+    const catalogue = trait(authored.xmlid, category, edition);
 
     if (catalogue === null) {
         return [
@@ -57,12 +65,25 @@ function validateComplication(authored: AuthoredComplication, index: number, edi
                 path,
                 // The specific trap: not "unknown", but "this edition doesn't have it". 6E deleted
                 // entries 5E had, and the engine's answer to a missing template is 0, not an error.
-                message: `${edition} has no complication "${authored.xmlid}". It would price at 0 rather than fail.`,
+                message: `${edition} has no ${CATEGORY_NOUN[category]} "${authored.xmlid}". It would price at 0 rather than fail.`,
             },
         ];
     }
 
-    const problems: Problem[] = [];
+    if (catalogue.unsupported !== null) {
+        return [
+            {
+                severity: 'error',
+                path,
+                message:
+                    catalogue.unsupported === 'bespoke'
+                        ? `${catalogue.display} needs a form of its own — it is priced by fields no template declares.`
+                        : `${catalogue.display} states no cost, so nothing here could price it.`,
+            },
+        ];
+    }
+
+    const problems: Problem[] = [...validateTraitFields(authored, catalogue, path)];
     const chosen = new Map(authored.adders.map((adder) => [adder.xmlid, adder]));
 
     for (const adder of catalogue.adders) {
@@ -109,10 +130,62 @@ function validateComplication(authored: AuthoredComplication, index: number, edi
 }
 
 /**
+ * The fields a trait carries in its own right — characteristic, option, levels, familiarity.
+ *
+ * Each of these fails silently rather than loudly, which is why they are errors and not warnings:
+ *   - a skill with no `characteristic` falls through `Skill.cost()` to its own `basecost`, which
+ *     most skills do not declare, so it costs 0 and still renders;
+ *   - `Roll` computes `base + trait.levels` unguarded, so a non-integer level prints "NaN-";
+ *   - `SkillLevels.cost()` divides by the *chosen option's* `lvlval`, so no option means
+ *     dividing by undefined.
+ */
+function validateTraitFields(authored: AuthoredTrait, catalogue: CatalogueTrait, path: string): Problem[] {
+    const problems: Problem[] = [];
+
+    if (catalogue.characteristics.length > 0 && authored.familiarity !== true) {
+        if (authored.characteristic === undefined) {
+            problems.push({severity: 'error', path, message: `${catalogue.display} must say which characteristic it rolls against.`});
+        } else if (!catalogue.characteristics.some((choice) => choice.characteristic === authored.characteristic)) {
+            problems.push({
+                severity: 'error',
+                path,
+                message: `${catalogue.display} cannot be based on ${authored.characteristic} — only ${catalogue.characteristics.map((choice) => choice.characteristic).join(', ')}.`,
+            });
+        }
+    }
+
+    if (catalogue.options.length > 0 && !catalogue.options.some((option) => option.xmlid === authored.option)) {
+        problems.push({
+            severity: 'error',
+            path,
+            message: `${catalogue.display} needs one of: ${catalogue.options.map((option) => option.display).join(', ')}.`,
+        });
+    }
+
+    if (authored.levels !== undefined && (!Number.isInteger(authored.levels) || authored.levels < 0)) {
+        problems.push({severity: 'error', path, message: `${catalogue.display} must have a whole, non-negative number of levels.`});
+    }
+
+    if (authored.familiarity === true && catalogue.familiarity === null) {
+        problems.push({severity: 'error', path, message: `${catalogue.display} cannot be taken at familiarity.`});
+    }
+
+    return problems;
+}
+
+/**
  * Every characteristic key this edition defines, as a set — anything else is not authorable.
  * Derived from the same catalogue the UI renders, so the two cannot disagree about what exists.
  */
 const authorableCharacteristics = (edition: AuthoringEdition): ReadonlySet<string> => new Set(characteristics(edition).map((entry) => entry.key));
+
+/** Where each catalogue category lives on a draft — `disadvantages` is called `complications` there. */
+const DRAFT_KEY: Readonly<Record<AuthorableCategory, 'skills' | 'perks' | 'talents' | 'complications'>> = {
+    skills: 'skills',
+    perks: 'perks',
+    talents: 'talents',
+    disadvantages: 'complications',
+};
 
 /**
  * Everything wrong with a draft, most severe first.
@@ -151,7 +224,9 @@ export function validate(draft: AuthoredCharacter): Problem[] {
         problems.push({severity: 'warning', path: 'complications', message: 'No complications taken.'});
     }
 
-    draft.complications.forEach((entry, index) => problems.push(...validateComplication(entry, index, draft.edition)));
+    for (const category of Object.keys(AUTHORABLE_CATEGORIES) as AuthorableCategory[]) {
+        draft[DRAFT_KEY[category]].forEach((entry, index) => problems.push(...validateTrait(entry, category, index, draft.edition)));
+    }
 
     return [...problems].sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'error' ? -1 : 1));
 }

--- a/src/core/authoring/validate.ts
+++ b/src/core/authoring/validate.ts
@@ -31,8 +31,8 @@
  *   - `error`   — the engine will mis-price or refuse this. Saving it produces a wrong character.
  *   - `warning` — legal, priced correctly, but probably not what was meant (over budget, blank).
  */
-import {AUTHORABLE_CATEGORIES, characteristics, complications, trait, type AuthorableCategory, type CatalogueTrait} from './catalogue';
-import type {AuthoredCharacter, AuthoredTrait, AuthoringEdition} from './types';
+import {AUTHORABLE_CATEGORIES, characteristics, complications, modifier, trait, type AuthorableCategory, type CatalogueTrait} from './catalogue';
+import type {AuthoredCharacter, AuthoredPower, AuthoredTrait, AuthoringEdition} from './types';
 
 export type Severity = 'error' | 'warning';
 
@@ -51,6 +51,7 @@ const CATEGORY_NOUN: Readonly<Record<AuthorableCategory, string>> = {
     skills: 'skill',
     perks: 'perk',
     talents: 'talent',
+    powers: 'power',
     disadvantages: 'complication',
 };
 
@@ -180,12 +181,70 @@ function validateTraitFields(authored: AuthoredTrait, catalogue: CatalogueTrait,
 const authorableCharacteristics = (edition: AuthoringEdition): ReadonlySet<string> => new Set(characteristics(edition).map((entry) => entry.key));
 
 /** Where each catalogue category lives on a draft — `disadvantages` is called `complications` there. */
-const DRAFT_KEY: Readonly<Record<AuthorableCategory, 'skills' | 'perks' | 'talents' | 'complications'>> = {
+const DRAFT_KEY: Readonly<Record<AuthorableCategory, 'skills' | 'perks' | 'talents' | 'powers' | 'complications'>> = {
     skills: 'skills',
     perks: 'perks',
     talents: 'talents',
+    powers: 'powers',
     disadvantages: 'complications',
 };
+
+/**
+ * A power's modifiers, and the fields no template describes.
+ *
+ * A modifier the edition does not define resolves to no template and contributes **nothing** to
+ * the multiplier, so the power comes out at its unmodified price and reads as though the advantage
+ * were free. Same failure as an unknown trait, one level down.
+ */
+function validatePower(power: AuthoredPower, index: number, edition: AuthoringEdition): Problem[] {
+    const path = `powers[${index}]`;
+    const catalogue = trait(power.xmlid, 'powers', edition);
+
+    if (catalogue === null || catalogue.unsupported !== null) {
+        return []; // already reported by validateTrait; saying it twice helps nobody
+    }
+
+    const problems: Problem[] = [];
+
+    for (const applied of power.modifiers) {
+        const entry = modifier(applied.xmlid, edition);
+
+        if (entry === null) {
+            problems.push({
+                severity: 'error',
+                path,
+                message: `${edition} has no modifier "${applied.xmlid}". It would change the cost by nothing at all.`,
+            });
+            continue;
+        }
+
+        if (entry.options.length > 0 && !entry.options.some((option) => option.xmlid === applied.option)) {
+            problems.push({severity: 'error', path, message: `"${entry.display}" needs one of: ${entry.options.map((option) => option.display).join(', ')}.`});
+        }
+
+        if (entry.freeText && (applied.text ?? '').trim() === '') {
+            problems.push({severity: 'error', path, message: `"${entry.display}" needs some text — it is what the sheet prints.`});
+        }
+    }
+
+    // A declared field group is not optional: `getResistantDefense` reads those numbers straight
+    // off the trait, so a Resistant Protection without them costs full price and defends nothing.
+    if (catalogue.fieldGroup !== null && power.defense === undefined) {
+        problems.push({severity: 'error', path, message: `${catalogue.display} needs its ${catalogue.fieldGroup.label.toLowerCase()} — without them it costs points and grants no defence.`});
+    }
+
+    if (power.defense !== undefined) {
+        const values = [power.defense.pd, power.defense.ed, power.defense.mental, power.defense.power];
+
+        if (values.some((value) => !Number.isInteger(value) || value < 0)) {
+            problems.push({severity: 'error', path, message: `${catalogue.display} must have whole, non-negative defences.`});
+        } else if (values.every((value) => value === 0)) {
+            problems.push({severity: 'warning', path, message: `${catalogue.display} grants no defence.`});
+        }
+    }
+
+    return problems;
+}
 
 /**
  * Everything wrong with a draft, most severe first.
@@ -227,6 +286,8 @@ export function validate(draft: AuthoredCharacter): Problem[] {
     for (const category of Object.keys(AUTHORABLE_CATEGORIES) as AuthorableCategory[]) {
         draft[DRAFT_KEY[category]].forEach((entry, index) => problems.push(...validateTrait(entry, category, index, draft.edition)));
     }
+
+    draft.powers.forEach((power, index) => problems.push(...validatePower(power, index, draft.edition)));
 
     return [...problems].sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'error' ? -1 : 1));
 }

--- a/src/core/hero/__tests__/goldenMaster.test.ts
+++ b/src/core/hero/__tests__/goldenMaster.test.ts
@@ -20,7 +20,7 @@
  * `getCharacter` mutates its input, so each side gets a fresh clone.
  */
 import manifest from './fixtures/manifest.json';
-import {heroDesignerCharacter as core} from 'core/hero';
+import {heroDesignerCharacter as core, TRAIT_CHILD_KEYS} from 'core/hero';
 
 // react-native + the toast module are stubbed project-wide via moduleNameMapper
 // (see jest.config.js). The App/Statistics reach-ins that Common→DieRoller drags
@@ -35,15 +35,72 @@ const legacy = require('../../../../../hero-system-mobile/src/lib/HeroDesignerCh
 const fixtures = manifest.map((entry) => entry.fixture).sort();
 const clone = (name: string): unknown => JSON.parse(JSON.stringify(require(`./fixtures/${name}.json`)));
 
+type Obj = Record<string, any>;
+
+/**
+ * H2 (docs/KNOWN_DEVIATIONS.md) — the one intentional divergence in this file, and it is a
+ * divergence of **arrangement only**.
+ *
+ * Legacy's boolean sort comparator could never move a trait earlier, so a framework container —
+ * which `normalizeCharacterItems` always appends last — was processed after its own slots, and
+ * every slot ended up beside its container instead of inside it. Sorting numerically puts the
+ * container back in front, and the slots nest.
+ *
+ * So for 27 of the 37 fixtures the two engines now build the same traits in a different *shape*.
+ * Rather than skip those characters wholesale — which would drop two thirds of the corpus out of
+ * the golden master — both sides are flattened to the same canonical arrangement and then compared
+ * in full. Every field of every trait, every attached template, every cost input is still pinned
+ * against legacy. The only thing this normalization forgives is which array a trait sits in and
+ * what order it appears in, which is exactly what H2 changes and nothing else.
+ *
+ * Costs are unaffected by the reshaping and are *not* forgiven anywhere: `getParent` resolves a
+ * container by scanning `character[listKey]` for the id, and the container is present either way.
+ * `traitSort.test.ts` pins that directly, and the decorator/query golden masters — which compare
+ * every cost in the corpus — were never re-based for H2 because nothing in them moved.
+ */
+const canonical = (character: Obj): Obj => {
+    const normalized: Obj = {...character};
+
+    for (const [key, childKeys] of Object.entries(TRAIT_CHILD_KEYS)) {
+        if (!Array.isArray(character[key])) {
+            continue;
+        }
+
+        const flat: Obj[] = [];
+        const hoist = (traits: Obj[]): void => {
+            for (const trait of traits) {
+                const copy: Obj = {...trait};
+
+                for (const childKey of childKeys) {
+                    if (Array.isArray(trait[childKey])) {
+                        hoist(trait[childKey] as Obj[]);
+                        copy[childKey] = []; // emptied on both sides, so a nested and a loose slot read alike
+                    }
+                }
+
+                flat.push(copy);
+            }
+        };
+
+        hoist(character[key] as Obj[]);
+
+        // Sorted by id, so "which array it was in" and "what order it came out in" both stop
+        // mattering. Ids are unique per character — HERO Designer stamps one on every element.
+        normalized[key] = flat.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+    }
+
+    return normalized;
+};
+
 describe('golden master: core/hero getCharacter reproduces legacy', () => {
     it('covers the whole corpus', () => {
         expect(fixtures.length).toBe(37);
     });
 
     it.each(fixtures)('%s matches legacy', (name) => {
-        const legacyCharacter = legacy.heroDesignerCharacter.getCharacter(clone(name));
-        const coreCharacter = core.getCharacter(clone(name) as never);
+        const legacyCharacter = legacy.heroDesignerCharacter.getCharacter(clone(name)) as Obj;
+        const coreCharacter = core.getCharacter(clone(name) as never) as unknown as Obj;
 
-        expect(coreCharacter).toEqual(legacyCharacter);
+        expect(canonical(coreCharacter)).toEqual(canonical(legacyCharacter));
     });
 });

--- a/src/core/hero/__tests__/traitSort.test.ts
+++ b/src/core/hero/__tests__/traitSort.test.ts
@@ -1,0 +1,139 @@
+// Copyright 2018-Present Philip J. Guinchard
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Correctness test for H2 (docs/KNOWN_DEVIATIONS.md) — legacy sorted traits with
+ * `(a, b) => a.position > b.position`, a comparator that returns a boolean. V8 coerces it to 0/1
+ * and never sees a negative, so no element can move earlier in the array: on anything already out
+ * of order the sort does nothing at all.
+ *
+ * **Legacy is not the oracle here**, and the correct behaviour is not a matter of HERO rules but of
+ * the `.hdc` format's own two statements about structure:
+ *
+ *   - `POSITION` is HERO Designer's document order. A list sorted by it must be ascending.
+ *   - `PARENTID` names a trait's container. A slot belongs *inside* its framework.
+ *
+ * The two are connected, which is why this was never only a display-order bug.
+ * `normalizeCharacterItems` moves every non-`power` sub-key — `<MULTIPOWER>`, `<ELEMENTALCONTROL>`,
+ * `<LINGUIST>` — onto the end of the category's list, so the container always arrives last no
+ * matter what its `POSITION` says. `populateTrait` then attaches each slot by looking its parent up
+ * in `character[traitKey]`, which has not been pushed yet; the lookup misses and the slot is
+ * appended at the top level. Sorting by position first is what puts the container back in front of
+ * its own slots.
+ *
+ * Costs are deliberately pinned here too. They must **not** move: `getParent` resolves a parent by
+ * scanning `character[listKey]` for the id, and the container sits there either way — which is why
+ * the Skill Enhancer discount (H12) went on working for years while the nesting was broken.
+ */
+import {heroDesignerCharacter, type ParsedCharacter} from 'core/hero';
+import {characterTraitDecorator} from 'core/traits';
+
+type Obj = Record<string, any>;
+
+const clone = (name: string): ParsedCharacter => JSON.parse(JSON.stringify(require(`./fixtures/${name}.json`))) as ParsedCharacter;
+const heroOf = (name: string): Obj => heroDesignerCharacter.getCharacter(clone(name)) as unknown as Obj;
+
+/** Every trait in a category, containers and nested slots alike. */
+const walk = (items: Obj[], key: string): Obj[] => items.flatMap((item) => [item, ...(Array.isArray(item[key]) ? walk(item[key] as Obj[], key) : [])]);
+
+describe('H2 — traits sort by position, so frameworks keep their slots', () => {
+    describe('the comparator orders ascending', () => {
+        it('sorts a shuffled category into position order', () => {
+            const character = heroOf('greyman');
+
+            const positions = (character.powers as Obj[]).map((power) => power.position as number);
+
+            expect(positions).toEqual([...positions].sort((a, b) => a - b));
+        });
+
+        it('sorts every category of every corpus character', () => {
+            for (const name of ['adamantinerebuild210109', 'm-championsmush', 'mikayla-priestess', 'indigo-bunting', 'psi-blade6']) {
+                const character = heroOf(name);
+
+                for (const key of ['skills', 'perks', 'talents', 'martialArts', 'powers', 'equipment', 'disadvantages']) {
+                    const positions = ((character[key] ?? []) as Obj[]).map((trait) => trait.position as number).filter((p) => typeof p === 'number');
+
+                    expect({[`${name}.${key}`]: positions}).toEqual({[`${name}.${key}`]: [...positions].sort((a, b) => a - b)});
+                }
+            }
+        });
+    });
+
+    describe('a framework contains its slots', () => {
+        it("greyman's Multipower holds its four slots, and they are not also loose at the top level", () => {
+            const powers = heroOf('greyman').powers as Obj[];
+            const multipower = powers.find((power) => power.originalType === 'multipower')!;
+
+            expect(multipower).toBeDefined();
+            expect((multipower.powers as Obj[]).map((slot) => slot.xmlid)).toEqual(['DISPEL', 'EGOATTACK', 'EGOATTACK', 'TELEPATHY']);
+
+            // Legacy left all four here, beside the container rather than inside it.
+            expect(powers.filter((power) => power.parentid !== undefined)).toEqual([]);
+        });
+
+        it("greyman's Linguist holds its languages — a Skill Enhancer nests under `skills`, not `powers`", () => {
+            const skills = heroOf('greyman').skills as Obj[];
+            const linguist = skills.find((skill) => String(skill.xmlid).toUpperCase() === 'LINGUIST')!;
+
+            expect(linguist).toBeDefined();
+            expect((linguist.skills as Obj[]).every((skill) => skill.xmlid === 'LANGUAGES')).toBe(true);
+            expect((linguist.skills as Obj[]).length).toBe(4);
+            expect(skills.filter((skill) => skill.parentid !== undefined)).toEqual([]);
+        });
+
+        it('leaves no orphaned slot in any category, in any corpus character', () => {
+            const orphans: string[] = [];
+
+            for (const name of ['adamantinerebuild210109', 'aoe', 'champions-9-11-teen-supers-blank', 'gravity-girl', 'greyman', 'indigo-bunting', 'jane-fawn', 'kizza-emberward', 'm-championsmush', 'mikayla-priestess', 'psi-blade6', 'spyder2022']) {
+                const character = heroOf(name);
+
+                for (const key of ['skills', 'perks', 'talents', 'martialArts', 'powers', 'equipment', 'disadvantages']) {
+                    const loose = ((character[key] ?? []) as Obj[]).filter((trait) => trait.parentid !== undefined);
+
+                    if (loose.length > 0) {
+                        orphans.push(`${name}.${key}: ${loose.length}`);
+                    }
+                }
+            }
+
+            expect(orphans).toEqual([]);
+        });
+    });
+
+    describe('nesting does not move a single cost', () => {
+        it("prices greyman's Multipower exactly as before — the pool and every slot", () => {
+            const character = heroOf('greyman');
+            const multipower = (character.powers as Obj[]).find((power) => power.originalType === 'multipower')!;
+            const costOf = (trait: Obj): number => characterTraitDecorator.decorate(trait, 'powers', () => character).realCost();
+
+            // Both values measured against the pre-fix engine and unchanged by it. The pool is its
+            // 60-point reserve less Unified Power (−¼): 60 / 1.25 = 48.
+            expect(costOf(multipower)).toBe(48);
+            expect((multipower.powers as Obj[]).map(costOf)).toEqual([5, 4, 5, 5]);
+        });
+
+        it('still gives greyman a free native tongue and a discounted paid one (H12) from inside the enhancer', () => {
+            const character = heroOf('greyman');
+            const languages = walk(character.skills as Obj[], 'skills').filter((skill) => skill.xmlid === 'LANGUAGES');
+            const priced = (label: string): number => {
+                const skill = languages.find((s) => [s.name, s.input, s.alias].includes(label))!;
+
+                return characterTraitDecorator.decorate(skill, 'skills', () => character).realCost();
+            };
+
+            expect(priced('Mandaarian')).toBe(0); // native, free — stays free under the enhancer
+            expect(priced('English')).toBe(2); // base 3, less the enhancer's 1
+        });
+    });
+});

--- a/src/core/hero/constants.ts
+++ b/src/core/hero/constants.ts
@@ -88,3 +88,27 @@ export const CHARACTER_TRAITS: Readonly<Record<string, string>> = {
     equipment: 'powers',
     disadvantages: 'disad',
 };
+
+/**
+ * Where a category's traits nest their children — the `characterSubTrait` argument
+ * `getCharacter` passes to `populateTrait`, which is what a framework container's slots and a
+ * Skill Enhancer's skills are pushed onto.
+ *
+ * **It is not the same key for every category**, and it is not `powers` for most of them: a
+ * Skill Enhancer's skills live under `skills`, a martial style's maneuvers under `maneuver`.
+ * Walking `powers` alone — which is the obvious thing to write — silently misses every nested
+ * trait outside the Powers section.
+ *
+ * `equipment` is the one category with two: `populateTrait` nests its framework slots under
+ * `power`, while `getCompoundPowers` nests compound children under `powers` regardless of
+ * category. Both have to be walked or compound equipment disappears.
+ */
+export const TRAIT_CHILD_KEYS: Readonly<Record<string, readonly string[]>> = {
+    skills: ['skills'],
+    perks: ['perks'],
+    talents: ['talents'],
+    martialArts: ['maneuver'],
+    powers: ['powers'],
+    equipment: ['power', 'powers'],
+    disadvantages: ['disadvantages'],
+};

--- a/src/core/hero/heroDesignerCharacter.ts
+++ b/src/core/hero/heroDesignerCharacter.ts
@@ -929,7 +929,13 @@ export class HeroDesignerCharacter {
             }
         }
 
-        trait[traitSubKey].sort((a: Obj, b: Obj) => Number(a.position > b.position));
+        // H2 (docs/KNOWN_DEVIATIONS.md): legacy returned a boolean here, which V8 coerces to 0/1 —
+        // never negative, so nothing can move earlier and the sort is a no-op on anything out of
+        // order. That is not merely cosmetic. `normalizeCharacterItems` appends every non-`power`
+        // sub-key (a Multipower, an Elemental Control, a Skill Enhancer) to the *end* of the list,
+        // so the container was processed after its own slots — and a slot whose parent is not in
+        // `character[traitKey]` yet is pushed to the top level instead of nesting under it.
+        trait[traitSubKey].sort((a: Obj, b: Obj) => a.position - b.position);
 
         for (const value of Object.values(trait[traitSubKey]) as Obj[]) {
             if (value.xmlid.toUpperCase() === GENERIC_OBJECT || SKILL_ENHANCERS.includes(value.xmlid.toUpperCase())) {

--- a/src/core/hero/heroDesignerCharacter.ts
+++ b/src/core/hero/heroDesignerCharacter.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {getTemplate} from 'core/templates';
+import {getTemplate, type TemplateInput} from 'core/templates';
 import {flatten, hasModifier, isEmptyObject, roundInPlayersFavor, toCamelCase, toMap, toSnakeCase} from 'core/util';
 import {
     BASE_MOVEMENT_MODES,
@@ -95,6 +95,30 @@ export class HeroDesignerCharacter {
         }
 
         return character;
+    }
+
+    /**
+     * A finalized template with its entries normalized the way `getCharacter` normalizes them —
+     * every item under its category's sub-key, and every one carrying an `xmlid`.
+     *
+     * Exposed for `core/authoring`, which needs the same catalogue the engine matches against. The
+     * xmlid of an entry under a special sub-key (`knowledgeSkill`, `combatLuck`, `contact`) is
+     * *derived*, not declared — `KNOWLEDGE_SKILL`, `COMBAT_LUCK`, `CONTACT` — and deriving it a
+     * second time somewhere else is how a catalogue comes to offer a trait the engine cannot match.
+     *
+     * Works on a deep clone: normalization mutates, and the built-in templates are shared.
+     *
+     * **The result contains duplicates.** `normalizeTemplateData` concatenates the entries it
+     * collected onto the sub-key array they partly came from, so every entry declared directly
+     * under `skill` appears twice. Harmless to the engine, which only ever looks one up by xmlid;
+     * a caller enumerating the catalogue has to de-duplicate.
+     */
+    normalizedTemplate(template: TemplateInput): Obj {
+        const cloned = JSON.parse(JSON.stringify(getTemplate(template))) as Obj;
+
+        this.normalizeTemplateData(cloned);
+
+        return cloned;
     }
 
     isFifth(character: Obj): boolean {

--- a/src/core/ports/persistence.ts
+++ b/src/core/ports/persistence.ts
@@ -129,10 +129,15 @@ export type Edition = '5E' | '6E';
 export type CharacterDocument = Record<string, unknown>;
 
 /**
- * Where a character came from. Only a generated one is editable: an imported `.hdc` is a faithful
- * view of a file the player owns, and the app has no business rewriting it.
+ * Where a character came from, and therefore whether — and *how* — it may be edited.
+ *
+ * An imported `.hdc` is a faithful view of a file the player owns, and the app has no business
+ * rewriting it. The other two are the app's own and are editable, but not through the same door:
+ * a generated character is revised by changing its {@link StoredRecipe} and re-rolling, an
+ * authored one by changing its {@link StoredSource} directly. Neither is edited in place — both
+ * rebuild the document from their input.
  */
-export type CharacterOrigin = 'generated' | 'imported';
+export type CharacterOrigin = 'generated' | 'imported' | 'authored';
 
 /**
  * The generator's recipe, round-tripped as JSON so a generated character can be re-rolled.
@@ -143,6 +148,16 @@ export type CharacterOrigin = 'generated' | 'imported';
  * depends on ports).
  */
 export type StoredRecipe = Record<string, unknown>;
+
+/**
+ * The `ParsedCharacter` an authored character was built from — the engine's *input*, kept because
+ * {@link CharacterDocument} is its output and the two are not interchangeable.
+ *
+ * Opaque here for the same reason the recipe is: persistence stores it and hands it back.
+ * `core/authoring` owns the shape and validates on the way back in, so a source written by an
+ * older build that no longer parses simply makes the character non-editable rather than crashing.
+ */
+export type StoredSource = Record<string, unknown>;
 
 /** Portrait bytes to store, or `null` to clear. */
 export interface PortraitInput {
@@ -202,6 +217,8 @@ export interface Character extends CharacterSummary {
     origin: CharacterOrigin;
     /** The recipe it was rolled from; null for imports, and for rolls predating the recipe column. */
     recipe: StoredRecipe | null;
+    /** The parsed input it was authored from; null for imports and generated characters. */
+    source: StoredSource | null;
 }
 
 /** Input to `save` — the caller provides lifted fields + a portrait-free document. */
@@ -225,6 +242,8 @@ export interface SaveCharacter {
     origin?: CharacterOrigin;
     /** Present → store; absent → keep existing (so a rename needn't restate the recipe). */
     recipe?: StoredRecipe | null;
+    /** Present → store; absent → keep existing (so a re-frame needn't restate the whole build). */
+    source?: StoredSource | null;
 }
 
 export interface CharacterRepository {

--- a/src/core/random/__tests__/generate.test.ts
+++ b/src/core/random/__tests__/generate.test.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 /** The generator itself — docs/RANDOM_CHARACTER.md. */
-import {heroDesignerCharacter} from 'core/hero';
+import {heroDesignerCharacter, TRAIT_CHILD_KEYS} from 'core/hero';
+import {withDescendants} from 'core/util';
 import {characterTraitDecorator} from 'core/traits';
 import type {Rng} from 'core/ports';
 import {fittableSkillsets, generatableArchetypes, generateRandomCharacter} from '../generate';
@@ -124,8 +125,12 @@ describe('generateRandomCharacter', () => {
         // Martial maneuvers are not powers, but their cost comes out of the powers balance — the
         // legacy prose folds them into `powersCost`. Count both or Martial Artist looks 15 short.
         const spentBy = (character: Obj): number =>
-            (character.powers as Obj[]).reduce((total, power) => total + characterTraitDecorator.decorate(power, 'powers', () => character).realCost(), 0) +
-            ((character.martialArts ?? []) as Obj[]).reduce(
+            // Descend into containers: a framework's slots nest under it (H2) and all of them cost.
+            withDescendants(character.powers as Obj[], TRAIT_CHILD_KEYS.powers).reduce(
+                (total, power) => total + characterTraitDecorator.decorate(power, 'powers', () => character).realCost(),
+                0,
+            ) +
+            withDescendants((character.martialArts ?? []) as Obj[], TRAIT_CHILD_KEYS.martialArts).reduce(
                 (total, maneuver) => total + characterTraitDecorator.decorate(maneuver, 'martialArts', () => character).realCost(),
                 0,
             );

--- a/src/core/random/__tests__/powerset.test.ts
+++ b/src/core/random/__tests__/powerset.test.ts
@@ -19,7 +19,8 @@
  * the allocator computes (`total − characteristics − skills`). Nothing here states a cost;
  * every number below is derived from the template data through the decorator stack.
  */
-import {heroDesignerCharacter} from 'core/hero';
+import {heroDesignerCharacter, TRAIT_CHILD_KEYS} from 'core/hero';
+import {withDescendants} from 'core/util';
 import {characterTraitDecorator} from 'core/traits';
 import {allocate, ARCHETYPES_5E} from '../allocate';
 import {buildCharacteristics} from '../characteristics';
@@ -40,7 +41,8 @@ const build = (index: number): Obj => {
 
 /** Costed through `core/traits` rather than the app's sheet — `core` must not reach into `app`. */
 const powerRows = (character: Obj): Array<{label: string; realCost: number; active: number}> =>
-    (character.powers as Obj[]).map((power) => {
+    // Framework slots nest under their container (H2), and every one of them costs points.
+    withDescendants(character.powers as Obj[], TRAIT_CHILD_KEYS.powers).map((power) => {
         const decorated = characterTraitDecorator.decorate(power, 'powers', () => character);
 
         return {label: String(power.name), realCost: decorated.realCost(), active: decorated.activeCost()};
@@ -52,7 +54,7 @@ const powerRows = (character: Obj): Array<{label: string; realCost: number; acti
  * balance check has to count both, or an archetype with maneuvers looks short by exactly them.
  */
 const martialRows = (character: Obj): Array<{label: string; realCost: number}> =>
-    ((character.martialArts ?? []) as Obj[]).map((maneuver) => ({
+    withDescendants((character.martialArts ?? []) as Obj[], TRAIT_CHILD_KEYS.martialArts).map((maneuver) => ({
         label: String(maneuver.name ?? maneuver.alias),
         realCost: characterTraitDecorator.decorate(maneuver, 'martialArts', () => character).realCost(),
     }));
@@ -122,10 +124,13 @@ describe('Energy Projector powerset — 5E Low Powered', () => {
         expect(rows.every((row) => Number.isFinite(row.realCost))).toBe(true);
         expect(heroDesignerCharacter.isFifth(character)).toBe(true);
 
-        // The frameworks resolve as frameworks, not as loose powers.
-        const flight = character.powers.find((power: Obj) => power.name === 'Soar');
-        const blast = character.powers.find((power: Obj) => power.name === 'Blast');
+        // The frameworks resolve as frameworks, not as loose powers — and their slots sit inside
+        // them (H2), so both are found by descending rather than by scanning the top level.
+        const slots = withDescendants(character.powers as Obj[], TRAIT_CHILD_KEYS.powers);
+        const flight = slots.find((power: Obj) => power.name === 'Soar')!;
+        const blast = slots.find((power: Obj) => power.name === 'Blast')!;
 
+        expect([flight, blast].every((slot) => slot !== undefined)).toBe(true);
         expect(heroDesignerCharacter.isPowerFrameworkItem(blast, character, 'multipower')).toBe(true);
         expect(heroDesignerCharacter.isPowerFrameworkItem(flight, character, 'elementalControl')).toBe(true);
     });
@@ -140,7 +145,11 @@ describe('Energy Projector powerset — 5E Low Powered', () => {
         // often carry affectsPrimary: false on defences, but that marks them alternate-form only
         // — a decision a player made about their character, not a default to copy.
         it('marks every power as always-on', () => {
-            expect((build(0).powers as Obj[]).every((power) => power.affectsPrimary && power.affectsTotal)).toBe(true);
+            // Slots included: a framework container carries no affects* flags of its own, so
+            // scanning the top level alone would skip every power that lives in one.
+            const powers = withDescendants(build(0).powers as Obj[], TRAIT_CHILD_KEYS.powers).filter((power) => power.type !== 'list');
+
+            expect(powers.every((power) => power.affectsPrimary && power.affectsTotal)).toBe(true);
         });
 
         it('totals the same in both forms, so there is nothing to toggle', () => {

--- a/src/core/random/__tests__/powersets6e.test.ts
+++ b/src/core/random/__tests__/powersets6e.test.ts
@@ -25,7 +25,8 @@
  * Neither is asserted from the data. The engine prices every power, and the Rule of X reads the
  * finished character — so a powerset cannot pass here by declaring anything about itself.
  */
-import {heroDesignerCharacter} from 'core/hero';
+import {heroDesignerCharacter, TRAIT_CHILD_KEYS} from 'core/hero';
+import {withDescendants} from 'core/util';
 import {getTemplate} from 'core/templates';
 import {characterTraitDecorator, type Obj} from 'core/traits';
 import {ARCHETYPES_6E, characteristicsBudget} from '../allocate';
@@ -71,7 +72,7 @@ const powersSpent = (character: Obj): number =>
     (['powers', 'martialArts'] as const).reduce(
         (total, key) =>
             total +
-            ((character[key] ?? []) as Obj[]).reduce((sum, trait) => {
+            withDescendants((character[key] ?? []) as Obj[], TRAIT_CHILD_KEYS[key]).reduce((sum, trait) => {
                 try {
                     return sum + characterTraitDecorator.decorate(trait, key, () => character).realCost();
                 } catch {

--- a/src/core/random/__tests__/recipe.test.ts
+++ b/src/core/random/__tests__/recipe.test.ts
@@ -19,7 +19,8 @@
  * are that a rebuild reproduces the roll exactly, and that every edit leaves a character the rules
  * still accept. Both are checked against the engine rather than asserted.
  */
-import {heroDesignerCharacter} from 'core/hero';
+import {heroDesignerCharacter, TRAIT_CHILD_KEYS} from 'core/hero';
+import {withDescendants} from 'core/util';
 import {characterTraitDecorator} from 'core/traits';
 import type {Rng} from 'core/ports';
 import {buildRecipe, generateRandomCharacter, rollRecipe} from '../generate';
@@ -61,14 +62,21 @@ const spentOn = (character: Obj, buckets: readonly string[]): number =>
     buckets.reduce(
         (total, bucket) =>
             total +
-            ((character[bucket] ?? []) as Obj[]).reduce((sum, trait) => sum + characterTraitDecorator.decorate(trait, bucket, () => character).realCost(), 0),
+            // Containers included: a framework's slots nest under it (H2) and every one costs.
+            withDescendants((character[bucket] ?? []) as Obj[], TRAIT_CHILD_KEYS[bucket]).reduce(
+                (sum, trait) => sum + characterTraitDecorator.decorate(trait, bucket, () => character).realCost(),
+                0,
+            ),
         0,
     );
 
 const powersCost = (character: Obj): number => spentOn(character, ['powers', 'martialArts']);
 const skillsCost = (character: Obj): number => spentOn(character, ['skills', 'perks', 'talents']);
 const complicationsCost = (character: Obj): number =>
-    (character.disadvantages as Obj[]).reduce((total, row) => total + characterTraitDecorator.decorate(row, 'disadvantages', () => character).cost(), 0);
+    withDescendants(character.disadvantages as Obj[], TRAIT_CHILD_KEYS.disadvantages).reduce(
+        (total, row) => total + characterTraitDecorator.decorate(row, 'disadvantages', () => character).cost(),
+        0,
+    );
 
 describe('CharacterRecipe', () => {
     /**

--- a/src/core/random/allocate.ts
+++ b/src/core/random/allocate.ts
@@ -30,8 +30,9 @@
  * chars − skills` reproduces its powerset sizes exactly (Energy Projector 125, Patriot 100,
  * Speedster 100, Brick 75), which is good evidence this was the original's design too.
  */
-import {heroDesignerCharacter} from 'core/hero';
+import {heroDesignerCharacter, TRAIT_CHILD_KEYS} from 'core/hero';
 import type {Rng} from 'core/ports';
+import {withDescendants} from 'core/util';
 import archetypeData from '../data/random/archetypes.5e.json';
 import archetypeData6E from '../data/random/archetypes.6e.json';
 import skillsetData from '../data/random/skillsets.json';
@@ -109,10 +110,12 @@ export function characteristicsBudget(archetype: Archetype, level: PowerLevel): 
 export function skillsBudget(skillset: StructuredSkillset, level: PowerLevel): number {
     const character = heroDesignerCharacter.getCharacter(attachSkillset(buildCharacteristics({}, level.template), skillset)) as unknown as Obj;
 
+    // Descend into containers: a Skill Enhancer nests the skills it discounts, and those skills are
+    // most of what a profession costs. Summing the top level alone reads a Scholar as its enhancer.
     return (['skills', 'perks', 'talents'] as const).reduce(
         (total, key) =>
             total +
-            ((character[key] ?? []) as Obj[]).reduce((sum, trait) => {
+            withDescendants((character[key] ?? []) as Obj[], TRAIT_CHILD_KEYS[key]).reduce((sum, trait) => {
                 try {
                     return sum + characterTraitDecorator.decorate(trait, key, () => character).realCost();
                 } catch {

--- a/src/core/random/ruleOfXStats.ts
+++ b/src/core/random/ruleOfXStats.ts
@@ -25,8 +25,9 @@
  * So: a wrong number here is a judgement to argue with, not a bug. Keeping it out of `ruleOfX.ts`
  * keeps the part that *can* be verified verifiable.
  */
-import {heroDesignerCharacter} from 'core/hero';
+import {heroDesignerCharacter, TRAIT_CHILD_KEYS} from 'core/hero';
 import {characterTraitDecorator, type Obj} from 'core/traits';
+import {withDescendants} from 'core/util';
 import type {RuleOfXStats} from './ruleOfX';
 
 /**
@@ -72,6 +73,15 @@ const MOVEMENT_POWERS: ReadonlySet<string> = new Set(['RUNNING', 'SWIMMING', 'LE
 const BASE_MOVEMENT: ReadonlySet<string> = new Set(['RUNNING', 'SWIMMING', 'LEAPING']);
 
 const toArray = (value: unknown): Obj[] => (Array.isArray(value) ? (value as Obj[]) : value === undefined || value === null ? [] : [value as Obj]);
+
+/**
+ * A category's traits, containers and nested slots alike.
+ *
+ * Every reader below is looking for traits of a kind — attacks, defences, Combat Skill Levels —
+ * and a framework slot is as much an attack as a standalone power is. Reading the top level only
+ * would score a character whose whole offence sits in a Multipower as having none.
+ */
+const traitsOf = (character: Obj, key: string): Obj[] => withDescendants(toArray(character[key]), TRAIT_CHILD_KEYS[key]);
 
 /** `getTotalDefense` hands back `"total/resistant"`; `getTotalUnusualDefense` does the same. */
 function splitDefense(value: string): {total: number; resistant: number} {
@@ -153,7 +163,7 @@ export function ruleOfXStats(built: Obj): RuleOfXStats {
     const pd = splitDefense(heroDesignerCharacter.getTotalDefense(character, 'PD'));
     const ed = splitDefense(heroDesignerCharacter.getTotalDefense(character, 'ED'));
 
-    const powers = toArray(character.powers);
+    const powers = traitsOf(character, 'powers');
     const attacks = powers.filter(isAttack);
     const defences = powers.filter(isDefensive);
 
@@ -167,13 +177,13 @@ export function ruleOfXStats(built: Obj): RuleOfXStats {
      * `_SINGLE` xmlid, and 6E folded that into an *option* of the one talent. Matching on
      * `LIGHTNING_REFLEXES` exactly, as this did, matched nothing at all.
      */
-    const lightningReflexes = toArray(character.talents)
+    const lightningReflexes = traitsOf(character, 'talents')
         .filter((talent) => String(talent.xmlid).toUpperCase().startsWith('LIGHTNING_REFLEXES'))
         .reduce((best, talent) => Math.max(best, Number(talent.levels) || 0), 0);
 
     // "All Combat Skill Levels the character owns". Skill Levels and Penalty Skill Levels are not
     // Combat Skill Levels, whatever their xmlid looks like.
-    const csl = toArray(character.skills)
+    const csl = traitsOf(character, 'skills')
         .filter((skill) => String(skill.xmlid).toUpperCase() === 'COMBAT_LEVELS')
         .reduce((sum, skill) => sum + (Number(skill.levels) || 0), 0);
 
@@ -188,7 +198,7 @@ export function ruleOfXStats(built: Obj): RuleOfXStats {
      * The bare punch is the floor, for a Brick with no attack power at all.
      */
     const punch = Math.floor(total('STR') / 5);
-    const maneuvers = toArray(character.martialArts).filter(doesDamage);
+    const maneuvers = traitsOf(character, 'martialArts').filter(doesDamage);
     const dc = Math.max(
         punch,
         ...attacks.filter(doesDamage).map((power) => damageClassesOf(power, 'powers', character)),

--- a/src/core/traits/__tests__/skillEnhancer.test.ts
+++ b/src/core/traits/__tests__/skillEnhancer.test.ts
@@ -20,7 +20,8 @@
  * agrees with HERO Designer, which prices a native tongue at 0 with or without Linguist — legacy is
  * wrong at these three corpus characters, so it is not the oracle.
  */
-import {heroDesignerCharacter as core} from 'core/hero';
+import {heroDesignerCharacter as core, TRAIT_CHILD_KEYS} from 'core/hero';
+import {withDescendants} from 'core/util';
 import {characterTraitDecorator} from '../index';
 import {CharacterTrait} from '../characterTrait';
 import ModifierCalculator from '../modifierCalculator';
@@ -29,7 +30,8 @@ const clone = (name: string): any => JSON.parse(JSON.stringify(require(`../../he
 
 /** The visible label a Language carries can live in `name`, `input`, or `alias` across the corpus. */
 const findLanguage = (character: any, label: string): any =>
-    character.skills.find((s: any) => s.xmlid === 'LANGUAGES' && [s.name, s.input, s.alias].includes(label));
+    // Under the enhancer, not beside it: a Skill Enhancer nests the skills it discounts (H2).
+    withDescendants(character.skills as any[], TRAIT_CHILD_KEYS.skills).find((s: any) => s.xmlid === 'LANGUAGES' && [s.name, s.input, s.alias].includes(label));
 
 /** A skill of the given base cost sitting under (or not under) a named parent, priced through ModifierCalculator. */
 const pricedUnder = (basecost: number, parentXmlid: string | null): number => {

--- a/src/core/util/common.ts
+++ b/src/core/util/common.ts
@@ -145,6 +145,34 @@ export const flatten = <T extends FlattenableItem>(items: T[], key: string): T[]
 };
 
 /**
+ * Every trait in `items`, depth-first, **including** the containers themselves.
+ *
+ * The difference from {@link flatten} is the container: `flatten` splices a framework away and
+ * returns only its slots, which is right for a totals query (the pool is not a power). Anything
+ * *summing costs* needs the opposite — a Multipower's pool costs real points, and so do its slots.
+ *
+ * Children may hang off more than one key: a framework nests its slots under the category's own
+ * child key (`powers.powers`, `skills.skills`, `martialArts.maneuver`), while a compound power
+ * always nests under `powers`. Equipment is the one category that sees both. Pass every key that
+ * applies — see `TRAIT_CHILD_KEYS` in `core/hero`.
+ */
+export const withDescendants = <T extends FlattenableItem>(items: T[], keys: readonly string[]): T[] => {
+    const walked: T[] = [];
+
+    for (const item of items) {
+        walked.push(item);
+
+        for (const key of keys) {
+            if (Array.isArray(item[key])) {
+                walked.push(...withDescendants(item[key] as T[], keys));
+            }
+        }
+    }
+
+    return walked;
+};
+
+/**
  * Indexes objects by a key. Collisions collapse into an array under that key —
  * a legacy quirk the rules engine depends on, preserved exactly.
  */

--- a/src/infra/persistence/__tests__/migrations.test.ts
+++ b/src/infra/persistence/__tests__/migrations.test.ts
@@ -23,10 +23,19 @@ describe('migrations (real SQLite)', () => {
     it('applies the base schema and records the version', () => {
         const db = createBetterSqlite3Database();
 
-        expect(runMigrations(db)).toBe(7);
+        expect(runMigrations(db)).toBe(8);
 
         expect(tables(db)).toEqual(expect.arrayContaining(['app_state', 'characters', 'combat_state', 'random_hero', 'schema_migrations', 'settings', 'statistics']));
-        expect(db.execute('SELECT version FROM schema_migrations ORDER BY version').rows).toEqual([{version: 1}, {version: 2}, {version: 3}, {version: 4}, {version: 5}, {version: 6}, {version: 7}]);
+        expect(db.execute('SELECT version FROM schema_migrations ORDER BY version').rows).toEqual([
+            {version: 1},
+            {version: 2},
+            {version: 3},
+            {version: 4},
+            {version: 5},
+            {version: 6},
+            {version: 7},
+            {version: 8},
+        ]);
         // Slots are retired — migration 003 drops the column.
         expect(tables(db)).not.toContain('slot');
         expect(db.execute('PRAGMA table_info(characters)').rows.some((row) => row.name === 'slot')).toBe(false);
@@ -39,7 +48,7 @@ describe('migrations (real SQLite)', () => {
         runMigrations(db);
         runMigrations(db);
 
-        expect(db.execute('SELECT COUNT(*) AS n FROM schema_migrations').rows[0].n).toBe(7);
+        expect(db.execute('SELECT COUNT(*) AS n FROM schema_migrations').rows[0].n).toBe(8);
     });
 
     it('removes combat state when its character is deleted (ON DELETE CASCADE)', () => {

--- a/src/infra/persistence/characterRepository.ts
+++ b/src/infra/persistence/characterRepository.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type {Character, CharacterOrigin, CharacterRepository, CharacterSummary, ImageStore, PortraitFocus, SaveCharacter, StoredRecipe} from 'core/ports';
+import type {Character, CharacterOrigin, CharacterRepository, CharacterSummary, ImageStore, PortraitFocus, SaveCharacter, StoredRecipe, StoredSource} from 'core/ports';
 import type {SqlDatabase, SqlRow} from './driver/sqlDatabase';
 
 const SUMMARY_COLUMNS = 'id, name, player, edition, is_active, portrait_id, portrait_focus_x, portrait_focus_y, portrait_focus_scale';
@@ -62,7 +62,7 @@ export class SqliteCharacterRepository implements CharacterRepository {
     }
 
     async save(character: SaveCharacter): Promise<void> {
-        const existing = this.db.execute('SELECT portrait_id, is_active, origin, recipe FROM characters WHERE id = ?', [character.id]).rows[0];
+        const existing = this.db.execute('SELECT portrait_id, is_active, origin, recipe, source FROM characters WHERE id = ?', [character.id]).rows[0];
         const existingPortraitId = (existing?.portrait_id as string | null) ?? null;
         const existingIsActive = existing ? (existing.is_active as number) : 0;
 
@@ -71,6 +71,7 @@ export class SqliteCharacterRepository implements CharacterRepository {
         // plain default on every save.
         const origin = character.origin ?? (existing?.origin as CharacterOrigin | undefined) ?? 'imported';
         const recipe = character.recipe === undefined ? ((existing?.recipe as string | null) ?? null) : character.recipe === null ? null : JSON.stringify(character.recipe);
+        const source = character.source === undefined ? ((existing?.source as string | null) ?? null) : character.source === null ? null : JSON.stringify(character.source);
 
         // Resolve the portrait: keep (undefined), clear (null), or store new (bytes).
         // Write the file before the row so a failed upsert only orphans an image
@@ -90,13 +91,13 @@ export class SqliteCharacterRepository implements CharacterRepository {
 
         this.db.transaction(() => {
             this.db.execute(
-                `INSERT INTO characters (id, name, player, edition, is_active, portrait_id, filename, data, updated_at, origin, recipe)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                `INSERT INTO characters (id, name, player, edition, is_active, portrait_id, filename, data, updated_at, origin, recipe, source)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name, player = excluded.player, edition = excluded.edition,
                     portrait_id = excluded.portrait_id, filename = excluded.filename,
                     data = excluded.data, updated_at = excluded.updated_at,
-                    origin = excluded.origin, recipe = excluded.recipe`,
+                    origin = excluded.origin, recipe = excluded.recipe, source = excluded.source`,
                 [
                     character.id,
                     character.name,
@@ -109,6 +110,7 @@ export class SqliteCharacterRepository implements CharacterRepository {
                     this.now(),
                     origin,
                     recipe,
+                    source,
                 ],
             );
         });
@@ -166,6 +168,7 @@ export class SqliteCharacterRepository implements CharacterRepository {
 
     private toCharacter(row: SqlRow): Character {
         const recipe = (row.recipe as string | null) ?? null;
+        const source = (row.source as string | null) ?? null;
 
         return {
             ...this.toSummary(row),
@@ -176,6 +179,8 @@ export class SqliteCharacterRepository implements CharacterRepository {
             // Shape is not checked here — `core/random` validates on the way back in, so a recipe
             // from an older build fails to parse there and the character simply isn't editable.
             recipe: recipe === null ? null : (JSON.parse(recipe) as StoredRecipe),
+            // Likewise unchecked here — `core/authoring` validates on the way back in.
+            source: source === null ? null : (JSON.parse(source) as StoredSource),
         };
     }
 }

--- a/src/infra/persistence/migrations.ts
+++ b/src/infra/persistence/migrations.ts
@@ -135,8 +135,38 @@ const migration007: Migration = {
     },
 };
 
+/**
+ * 008 — the authoring source: the `ParsedCharacter` an authored character was built from.
+ *
+ * A generated character is rebuilt from its `recipe`; an authored one has no recipe, because the
+ * player *is* the recipe. What it needs kept instead is the engine's **input** — and the `data`
+ * column holds the output, which does not round-trip. `populateMovementAndCharacteristics` keeps
+ * nine fields per characteristic and discards the parsed entry, so an adder or modifier bought on
+ * a characteristic is simply gone from the stored document.
+ *
+ * Its own column rather than a corner of `data`, for the reason the recipe got one: `data` is
+ * engine output and putting non-HERO data inside it would make the document a liar.
+ *
+ * NULL for imports and for generated characters, which say what they are in `recipe`.
+ */
+const migration008: Migration = {
+    version: 8,
+    up(db) {
+        db.execute('ALTER TABLE characters ADD COLUMN source TEXT');
+    },
+};
+
 /** All migrations, in ascending version order. */
-export const MIGRATIONS: readonly Migration[] = [migration001, migration002, migration003, migration004, migration005, migration006, migration007];
+export const MIGRATIONS: readonly Migration[] = [
+    migration001,
+    migration002,
+    migration003,
+    migration004,
+    migration005,
+    migration006,
+    migration007,
+    migration008,
+];
 
 /**
  * Apply every migration newer than the recorded schema version, each in its own


### PR DESCRIPTION
Authoring a character in the app, plus the engine fix that had to land first.

16 commits, ~7.5k lines. **87 suites / 2216 tests green**, `tsc` and lint clean.
Staged as **69 / 2.8.0**, schema 7 → 8. iOS 2.8.0 (1) is already on TestFlight
from this branch.

## Read this first: H2 changes existing characters

`abeffb9` + `5a42904` fix **H2**, and it is the only thing here that touches
something people already have.

`populateTrait` sorted with `(a, b) => Number(a.position > b.position)` — a
comparator that never returns a negative, so nothing could move earlier in the
array. Framework containers are appended *last* by `normalizeCharacterItems`, so
a container was processed after its own slots, the `parentid` lookup missed, and
every slot was pushed to the top level instead of nesting.

**27 of the 37 corpus fixtures** had orphaned slots; `m-championsmush` had 148.
`greyman`'s Multipower held 0 of its 4.

**No costs move.** `getParent` resolves a container by scanning the flat list and
the container was sitting there either way, so the Skill Enhancer discount (H12)
and framework slot pricing were always right. What was wrong was arrangement —
which is why no cost test ever caught it, and why the ledger had this filed as
cosmetic since the port began.

For review: a **cost** that moves on a framework is a regression; a **layout**
that moves is the fix.

The hero golden master is re-based to compare a canonical arrangement rather than
skipping the 27 fixtures — every field, template and cost is still pinned against
legacy. I verified it still fails on a deliberate one-level perturbation (11
fixtures caught) and still passes against the pre-fix engine, so it forgives
arrangement and nothing else.

## What the feature does

`core/authoring/` — pure core, no RN — takes a **draft** (what the player chose, by
xmlid) and emits the `.hdc`-shaped `ParsedCharacter` the engine already prices. So
a built character is priced by the same code that reads a HERO Designer file.

Characteristics, skills, perks, talents, powers with advantages/limitations,
frameworks (Multipower / Elemental Control / VPP), martial arts, equipment,
complications. Campaign allowance is pickable; anything spent past it is tracked
as experience and declared on the character.

Two screens: `AuthorCharacterScreen` (a row per trait, with its cost) and
`AuthorTraitScreen` (one trait's form). The draft lives in a provider because both
edit it and route params are for identifiers, not whole characters.

**Every field is generated from the rules templates.** Nothing in the UI names a
specific trait — the catalogue says what an entry declares and the form draws it.
Phases B–E added five categories and no per-trait UI code.

## Persistence

Migration 008 adds a nullable `source` column; `origin` gains `'authored'`. The
`data` column holds the engine's *output* and does not round-trip
(`populateMovementAndCharacteristics` keeps nine fields per characteristic), so an
authored character is rebuilt from its stored input — the same shape a generated
one uses with its `recipe`. Older sources missing a newer key read as empty rather
than unreadable, so a schema addition can't lock anyone out of saved work.

## What I'd look at

- **`5a42904`** — the H2 fix and the golden-master re-base. The consequential one.
- **`core/authoring/validate.ts`** — the concern with no prior counterpart.
  `getCharacter` prices; it does not judge, and never needed to, because a `.hdc`
  from HERO Designer was legal by construction. An xmlid the edition lacks
  resolves to no template and prices at **0**, so a typo becomes a free power.
  Every error case in the tests is paired with a demonstration of the silent
  failure it prevents.
- **`emit.ts`** — the recurring lesson, learned three separate times: **the
  template is consulted for prices, the trait for everything else.** `basecost`,
  Resistant Protection's defence split and a maneuver's combat line all have to be
  copied onto the trait, or the thing prices correctly and does nothing.

## Found and recorded, not fixed

**H13** — `MultipowerItem` reads `ultraSlot` off the `CharacterTrait` wrapper
rather than the trait, behind a cast that stops the compiler objecting. The
wrapper has no such field, so every Multipower slot divides by 10 whatever kind it
is. Not corpus-triggered (all 37 fixtures use fixed slots, for which ÷10 is
right), so no golden master can see it. Left for its own commit — the ratio needs
a rules check, and authoring ships fixed slots only and says so.

**Equipment never reaches the totals.** `powersForTotals` reads `character.powers`
and nothing reads `character.equipment`, so a Resistant Protection bought as gear
costs points and grants no defence. Faithful to legacy, pinned rather than papered
over; authoring warns instead.

## Could be split

`abeffb9` + `5a42904` (H2) are separable if you'd rather review the engine change
on its own — everything after depends on them, so it'd be a stacked PR rather than
two independent ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
