### PR TITLE
ios: commit the privacy manifest that only existed on the build box

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,11 +15,17 @@ listing. Two consequences:
   (`android/app/build.gradle`, which carries the full version history in a comment).
   Bump `versionCode` for every subsequent upload.
 
-The iOS side is versioned in `ios/herogmtools.xcodeproj/project.pbxproj`
-(`MARKETING_VERSION` / `CURRENT_PROJECT_VERSION`), kept in step with Android. It sat at
-the React Native default of **1.0 (1)** until 2.9.0, while 2.8.0 shipped to TestFlight as
-"2.8.0 (1)" — so it was being set by hand in Xcode on the build box and the repo said
-something different from what shipped. It is now correct here; set it here in future.
+**The iOS version does not come from the project file.** `build-signed.sh <marketing> <build>`
+on the Mac passes `MARKETING_VERSION`, `CURRENT_PROJECT_VERSION` **and**
+`TARGETED_DEVICE_FAMILY="1,2"` straight to `xcodebuild`, which overrides whatever
+`project.pbxproj` says. That is why the project file sat at the React Native default of
+`1.0 (1)` while 2.7.x and 2.8.0 all shipped to TestFlight correctly versioned — the file
+was simply never consulted.
+
+The pbxproj values are now kept in step with Android anyway, so opening the project in
+Xcode shows something truthful, but **the build script is the source of truth** and the
+version you type on its command line is the version that ships. Don't "fix" a release by
+editing the project file.
 
 ## Signing setup
 

--- a/ios/herogmtools.xcodeproj/project.pbxproj
+++ b/ios/herogmtools.xcodeproj/project.pbxproj
@@ -10,21 +10,11 @@
 		0C80B921A6F3F58F76C31292 /* libPods-herogmtools.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-herogmtools.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
+		7A5F56C2C8294A037B983A3A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		00E356F41AD99517003FC87E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
-			remoteInfo = herogmtools;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
-		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* herogmtools.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = herogmtools.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = herogmtools/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = herogmtools/Info.plist; sourceTree = "<group>"; };
@@ -49,14 +39,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		00E356F01AD99517003FC87E /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				00E356F11AD99517003FC87E /* Info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
 		13B07FAE1A68108700A75B9A /* herogmtools */ = {
 			isa = PBXGroup;
 			children = (
@@ -172,19 +154,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		00E356EC1AD99517003FC87E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F8E1A680F5B00A75B9A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				7A5F56C2C8294A037B983A3A /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -276,14 +252,6 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		00E356F51AD99517003FC87E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 13B07F861A680F5B00A75B9A /* herogmtools */;
-			targetProxy = 00E356F41AD99517003FC87E /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -305,7 +273,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.diceless.herogmtools";
+				PRODUCT_BUNDLE_IDENTIFIER = org.diceless.herogmtools;
 				PRODUCT_NAME = herogmtools;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -332,7 +300,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.diceless.herogmtools";
+				PRODUCT_BUNDLE_IDENTIFIER = org.diceless.herogmtools;
 				PRODUCT_NAME = herogmtools;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -408,7 +376,14 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				USE_HERMES = true;
 			};
 			name = Debug;
 		};
@@ -473,7 +448,13 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/ios/herogmtools/PrivacyInfo.xcprivacy
+++ b/ios/herogmtools/PrivacyInfo.xcprivacy
@@ -10,6 +10,7 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
+				<string>0A2A.1</string>
 			</array>
 		</dict>
 		<dict>
@@ -18,6 +19,15 @@
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
+				<string>E174.1</string>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
Found while preparing the 2.9.0 iOS build.

## The problem

`ios/herogmtools/PrivacyInfo.xcprivacy` and its wiring in `project.pbxproj` were edited **on the EC2 Mac** during the 2.8.0 release and never committed back. They declare the disk-space API category and two extra reason codes, and the project file adds the manifest to the app's Resources build phase — which is what Apple's privacy-manifest requirement actually checks.

So **the last two TestFlight uploads succeeded because of four uncommitted files sitting on a Dedicated Host with a 24-hour clock on it.** That is exactly how the build/sign scripts were lost with the earlier instances — the memory note already records that lesson. This stops it happening to the iOS project too.

The patch was taken off the box and applies cleanly; it does not touch the version lines.

## A correction

The note I added with the 2.9.0 bump had the reasoning wrong, and this fixes it.

`build-signed.sh <marketing> <build>` passes `MARKETING_VERSION`, `CURRENT_PROJECT_VERSION` **and** `TARGETED_DEVICE_FAMILY="1,2"` straight to `xcodebuild`, which overrides whatever the project file says. That is why the pbxproj sat at the React Native default `1.0 (1)` while 2.7.x and 2.8.0 all shipped correctly versioned — **the file was never consulted.**

Keeping it in step with Android is still worth doing so Xcode shows something truthful, but the build script is the source of truth, and RELEASE.md now says so explicitly with a warning not to 'fix' a release by editing the project file.

## Checks

- No JS/TS touched — iOS project and docs only
- The EC2 box will build 2.9.0 from this branch, so the upload itself is the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)